### PR TITLE
Use MessagePack in several network events

### DIFF
--- a/UTanksServer/Network/NetworkEvents/Communications/RestoreConnection.cs
+++ b/UTanksServer/Network/NetworkEvents/Communications/RestoreConnection.cs
@@ -1,15 +1,27 @@
-﻿using UTanksServer.Network.Simple.Net;
+using MessagePack;
+using UTanksServer;
+using UTanksServer.Network.Simple.Net;
 
 namespace UTanksServer.Network.NetworkEvents.Communications
 {
+    [MessagePackObject]
     public struct RestoreConnection : INetSerializable
     {
+        [Key(0)]
         public long uid;
 
         public void Serialize(NetWriter writer)
-            => writer.Push(uid);
+        {
+            var bytes = MessagePackSerializer.Serialize(this,
+                MessagePackSerializerOptions.Standard.WithCompression(MessagePackCompression.Lz4Block));
+            writer.buffer.AddRange(bytes);
+        }
 
         public void Deserialize(NetReader reader)
-            => uid = reader.ReadInt64();
+        {
+            var bytes = reader.ReadRemainingBytes();
+            this = MessagePackSerializer.Deserialize<RestoreConnection>(bytes,
+                MessagePackSerializerOptions.Standard.WithCompression(MessagePackCompression.Lz4Block));
+        }
     }
 }

--- a/UTanksServer/Network/NetworkEvents/FastGameEvents/RawMovementEvent.cs
+++ b/UTanksServer/Network/NetworkEvents/FastGameEvents/RawMovementEvent.cs
@@ -1,59 +1,43 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using MessagePack;
+using UTanksServer;
 using UTanksServer.ECS.Types.Battle;
 using UTanksServer.Network.Simple.Net;
 
 namespace UTanksServer.Network.NetworkEvents.FastGameEvents
 {
+    [MessagePackObject]
     public struct RawMovementEvent : INetSerializable
     {
-        public int packetId;
-        public long PlayerEntityId;
-        public Vector3S position;
-        public Vector3S velocity;
-        public Vector3S angularVelocity;
-        public QuaternionS rotation;
-        public QuaternionS turretRotation;
-        public float WeaponRotation { get; set; } //angle
-        public float TankMoveControl { get; set; }
-        public float TankTurnControl { get; set; }
-        public float WeaponRotationControl { get; set; }
-
-        public int ClientTime { get; set; }
+        [Key(0)] public int packetId;
+        [Key(1)] public long PlayerEntityId;
+        [Key(2)] public Vector3S position;
+        [Key(3)] public Vector3S velocity;
+        [Key(4)] public Vector3S angularVelocity;
+        [Key(5)] public QuaternionS rotation;
+        [Key(6)] public QuaternionS turretRotation;
+        [Key(7)] public float WeaponRotation { get; set; }
+        [Key(8)] public float TankMoveControl { get; set; }
+        [Key(9)] public float TankTurnControl { get; set; }
+        [Key(10)] public float WeaponRotationControl { get; set; }
+        [Key(11)] public int ClientTime { get; set; }
 
         public void Serialize(NetWriter writer)
         {
-            writer.Push(packetId);
-            writer.Push(PlayerEntityId);
-            writer.Push(position);
-            writer.Push(velocity);
-            writer.Push(angularVelocity);
-            writer.Push(rotation);
-            writer.Push(turretRotation);
-            writer.Push(WeaponRotation);
-            writer.Push(TankMoveControl);
-            writer.Push(TankTurnControl);
-            writer.Push(WeaponRotationControl);
-            writer.Push(ClientTime);
+            var bytes = MessagePackSerializer.Serialize(this,
+                MessagePackSerializerOptions.Standard.WithCompression(MessagePackCompression.Lz4Block));
+            writer.buffer.AddRange(bytes);
         }
 
         public void Deserialize(NetReader reader)
         {
-            packetId = (int)reader.ReadInt64();
-            PlayerEntityId = reader.ReadInt64();
-            position = reader.ReadVector3();
-            velocity = reader.ReadVector3();
-            angularVelocity = reader.ReadVector3();
-            rotation = reader.ReadQuaternion3();
-            turretRotation = reader.ReadQuaternion3();
-            WeaponRotation = reader.ReadFloat();
-            TankMoveControl = reader.ReadFloat();
-            TankTurnControl = reader.ReadFloat();
-            WeaponRotationControl = reader.ReadFloat();
-            ClientTime = (int)reader.ReadInt64();
+            var bytes = reader.ReadRemainingBytes();
+            this = MessagePackSerializer.Deserialize<RawMovementEvent>(bytes,
+                MessagePackSerializerOptions.Standard.WithCompression(MessagePackCompression.Lz4Block));
         }
     }
 }

--- a/UTanksServer/Network/NetworkEvents/GameData/GameEvent.cs
+++ b/UTanksServer/Network/NetworkEvents/GameData/GameEvent.cs
@@ -1,31 +1,34 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using MessagePack;
+using UTanksServer;
 using UTanksServer.Network.Simple.Net;
 
 namespace Assets.ClientCore.CoreImpl.Network.NetworkEvents.GameData
 {
     //this events automatically resending into ECSEventManager, in json store all needed data for ecs event
+    [MessagePackObject]
     public struct GameDataEvent : INetSerializable
     {
-        public int packetId;
-        public long typeId;
-        public string jsonData;
+        [Key(0)] public int packetId;
+        [Key(1)] public long typeId;
+        [Key(2)] public string jsonData;
 
         public void Serialize(NetWriter writer)
         {
-            writer.Push(packetId);
-            writer.Push(typeId);
-            writer.Push(jsonData);
+            var bytes = MessagePackSerializer.Serialize(this,
+                MessagePackSerializerOptions.Standard.WithCompression(MessagePackCompression.Lz4Block));
+            writer.buffer.AddRange(bytes);
         }
 
         public void Deserialize(NetReader reader)
         {
-            packetId = (int)reader.ReadInt64();
-            typeId = reader.ReadInt64();
-            jsonData = reader.ReadString();
+            var bytes = reader.ReadRemainingBytes();
+            this = MessagePackSerializer.Deserialize<GameDataEvent>(bytes,
+                MessagePackSerializerOptions.Standard.WithCompression(MessagePackCompression.Lz4Block));
         }
     }
 }

--- a/UTanksServer/Network/NetworkEvents/PlayerAuth/GetUserViaUsername.cs
+++ b/UTanksServer/Network/NetworkEvents/PlayerAuth/GetUserViaUsername.cs
@@ -1,22 +1,29 @@
+using MessagePack;
+using UTanksServer;
 using UTanksServer.Network.Simple.Net;
 
 namespace UTanksServer.Network.NetworkEvents.PlayerAuth
 {
+    [MessagePackObject]
     public struct GetUserViaUsername : INetSerializable
     {
+        [Key(0)]
         public int packetId;
+        [Key(1)]
         public string Username;
 
         public void Serialize(NetWriter writer)
         {
-            writer.Push(packetId);
-            writer.Push(Username);
+            var bytes = MessagePackSerializer.Serialize(this,
+                MessagePackSerializerOptions.Standard.WithCompression(MessagePackCompression.Lz4Block));
+            writer.buffer.AddRange(bytes);
         }
 
         public void Deserialize(NetReader reader)
         {
-            packetId = (int)reader.ReadInt64();
-            Username = reader.ReadString();
+            var bytes = reader.ReadRemainingBytes();
+            this = MessagePackSerializer.Deserialize<GetUserViaUsername>(bytes,
+                MessagePackSerializerOptions.Standard.WithCompression(MessagePackCompression.Lz4Block));
         }
     }
 }

--- a/UTanksServer/Network/Simple.Net/NetReader.cs
+++ b/UTanksServer/Network/Simple.Net/NetReader.cs
@@ -4,6 +4,7 @@ using System.Text;
 using UTanksServer.ECS.Components.Battle.AdditionalLogicComponents;
 using UTanksServer.ECS.Types.Battle;
 using UTanksServer.ECS.Types.Battle.AtomicType;
+using UTanksServer;
 
 namespace UTanksServer.Network.Simple.Net {
     public class NetReader : NetBuffer {
@@ -194,6 +195,13 @@ namespace UTanksServer.Network.Simple.Net {
             {
                 throw new OverflowException("Cannot read Dictionary!");
             }
+        }
+
+        public byte[] ReadRemainingBytes()
+        {
+            var bytes = buffer.ToArray().SubArray(readPos, buffer.Count - readPos);
+            readPos = buffer.Count;
+            return bytes;
         }
     }
 }

--- a/UTanksServer/UTanksServer.csproj
+++ b/UTanksServer/UTanksServer.csproj
@@ -65,6 +65,7 @@
     <PackageReference Include="RestSharp" Version="106.13.0" />
     <PackageReference Include="Serilog" Version="2.10.0" />
     <PackageReference Include="SharpZipLib" Version="1.3.3" />
+    <PackageReference Include="MessagePack" Version="2.5.99" />
     <PackageReference Include="System.Data.SQLite" Version="1.0.115.5" />
     <PackageReference Include="YamlDotNet" Version="11.2.1" />
   </ItemGroup>


### PR DESCRIPTION
## Summary
- add MessagePack package
- apply MessagePack serialization to various network events
- include helper for reading remaining bytes from `NetReader`

## Testing
- `dotnet build UTanksServer/UTanksServer.csproj -c Release` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6864ecd6d1188331913d7c6430133ca7