### PR TITLE
Implement basic connection handling and config

### DIFF
--- a/Config/Database.json
+++ b/Config/Database.json
@@ -1,0 +1,8 @@
+{
+  "host": "127.0.0.1",
+  "port": 3306,
+  "username": "araumi",
+  "password": "araumi",
+  "database": "araumi",
+  "version": "10.6.4"
+}

--- a/README.md
+++ b/README.md
@@ -1,0 +1,22 @@
+# UTanks Server
+
+This repository contains the game server implementation used for experiments. Many components are under active development.
+
+## Requirements
+- .NET 5 SDK
+- MariaDB or MySQL instance
+
+## Setup
+1. Copy configuration files from `Config/` and edit them if necessary.
+   Database connection settings are stored in `Config/Database.json`.
+2. Restore NuGet packages and build:
+   ```bash
+   dotnet build UTanksServer/UTanksServer.csproj
+   ```
+3. Run the server:
+   ```bash
+   dotnet run --project UTanksServer/UTanksServer.csproj
+   ```
+
+## Deployment
+Adjust the configuration files and run the server on your target machine. The static server and game server endpoints are configured via JSON files and loaded at startup.

--- a/UTanksServer/ECS/ECSCore/SystemManager.cs
+++ b/UTanksServer/ECS/ECSCore/SystemManager.cs
@@ -54,19 +54,15 @@ namespace UTanksServer.ECS.ECSCore
                 return;
             foreach(var SystemPair in SystemsInterestedEntityDatabase)
             {
-                if (Interlocked.Equals(SystemPair.Key.Enabled, true) && Interlocked.Equals(SystemPair.Key.InWork, false) && SystemPair.Key.LastEndExecutionTimestamp + DateTimeExtensions.MillisecondToTicks
-                    (SystemPair.Key.DelayRunMilliseconds) < DateTime.Now.Ticks)
+                if (Interlocked.Equals(SystemPair.Key.Enabled, true) &&
+                    Interlocked.Equals(SystemPair.Key.InWork, false) &&
+                    SystemPair.Key.LastEndExecutionTimestamp + DateTimeExtensions.MillisecondToTicks(SystemPair.Key.DelayRunMilliseconds) < DateTime.Now.Ticks)
                 {
-                    Func<Task> asyncUpd = async () =>
-                    {
-                        SystemPair.Key.InWork = true;
-                        await Task.Run(() => {
-                            SystemPair.Key.Run(SystemsInterestedEntityDatabase[SystemPair.Key].Keys.ToArray());
-                        });
-                    };
-                    asyncUpd();
+                    SystemPair.Key.InWork = true;
+                    SystemPair.Key.Run(SystemsInterestedEntityDatabase[SystemPair.Key].Keys.ToArray());
+                    SystemPair.Key.InWork = false;
                 }
-                    
+
             }
         }
 

--- a/UTanksServer/ECS/Systems/Battles/BattlesSystem.cs
+++ b/UTanksServer/ECS/Systems/Battles/BattlesSystem.cs
@@ -56,7 +56,7 @@ namespace UTanksServer.ECS.Systems.Battles
             });
             SystemEventHandler.Add(BattleLoadedEvent.Id, new List<Func<ECSEvent, object>>() {
                 (Event) => {
-                    PlayerReadyToBattle(Event as BattleLoadedEvent);
+                    _ = PlayerReadyToBattle(Event as BattleLoadedEvent);
                     Event.eventWatcher.Watchers--;
                     return null;
                 }
@@ -546,14 +546,14 @@ namespace UTanksServer.ECS.Systems.Battles
 
         #region BattleEvents
 
-        public void PlayerReadyToBattle(BattleLoadedEvent battleLoadedEvent)
+        public async Task PlayerReadyToBattle(BattleLoadedEvent battleLoadedEvent)
         {
             var battleEntity = ManagerScope.entityManager.EntityStorage[battleLoadedEvent.BattleId];
             var player = ManagerScope.entityManager.EntityStorage[battleLoadedEvent.EntityOwnerId];
             var teamComp = player.TryGetComponent<TeamComponent>();
             while(teamComp == null)
             {
-                Thread.Sleep(50);
+                await Task.Delay(50);
                 teamComp = player.TryGetComponent<TeamComponent>();
             }
 

--- a/UTanksServer/Lobby/DatabaseContext.cs
+++ b/UTanksServer/Lobby/DatabaseContext.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using System.Net;
+using System.IO;
 
 using Serilog;
 
@@ -12,20 +13,18 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using UTanksServer.Extensions;
 using UTanksServer.Services.Servers.Game;
 
+using Newtonsoft.Json;
+
 using Microsoft.EntityFrameworkCore.Design;
 using Microsoft.EntityFrameworkCore.Metadata;
 
 namespace UTanksServer.Database {
   public class DatabaseContextFactory : IDesignTimeDbContextFactory<DatabaseContext> {
     public DatabaseContext CreateDbContext(string[] args) {
-      return new DatabaseContext(new DatabaseConfig() {
-        Host = "127.0.0.1",
-        Port = 3306,
-        Username = "araumi",
-        Password = "araumi",
-        Database = "araumi",
-        Version = "10.6.4"
-      });
+      string json = File.ReadAllText(Path.Combine("Config", "Database.json"));
+      DatabaseConfig config = JsonConvert.DeserializeObject<DatabaseConfig>(json)!;
+
+      return new DatabaseContext(config);
     }
   }
 

--- a/UTanksServer/Services/Servers/Game/Connection/PlayerSocketConnection.cs
+++ b/UTanksServer/Services/Servers/Game/Connection/PlayerSocketConnection.cs
@@ -1,191 +1,183 @@
-//using System;
-//using System.IO;
-//using System.Net;
-//using System.Linq;
-//using System.Threading;
-//using System.Net.Sockets;
-//using System.Threading.Tasks;
-//using System.Collections.Generic;
-//using System.Text;
-//using Serilog;
-//using UTanksServer.Extensions;
+using System;
+using System.IO;
+using System.Net;
+using System.Linq;
+using System.Threading;
+using System.Net.Sockets;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+using System.Text;
+using Serilog;
+using UTanksServer.Extensions;
 
-//namespace UTanksServer.Services.Servers.Game.Connection
-//{
-//    public class PlayerSocketConnection : IPlayerConnection
-//    {
-//        private static readonly ILogger Logger = Log.Logger.ForType<PlayerSocketConnection>();
+namespace UTanksServer.Services.Servers.Game.Connection
+{
+    public class PlayerSocketConnection : IPlayerConnection
+    {
+        private static readonly ILogger Logger = Log.Logger.ForType<PlayerSocketConnection>();
 
-//        public Player Player { get; set; }
+        public Player Player { get; set; }
 
-//        public bool IsConnected { get; protected set; }
+        public bool IsConnected { get; protected set; }
 
-//        public Socket Socket { get; }
-//        public IPEndPoint Endpoint => (IPEndPoint)Socket.RemoteEndPoint;
+        public Socket Socket { get; }
+        public IPEndPoint Endpoint => (IPEndPoint)Socket.RemoteEndPoint;
 
-//        public AsyncQueue<ICommand> CommandQueue { get; }
+        public AsyncQueue<ICommand> CommandQueue { get; }
 
-//        private readonly CancellationTokenSource _cancellationTokenSource;
+        private readonly CancellationTokenSource _cancellationTokenSource;
 
-//        public PlayerSocketConnection(Socket socket)
-//        {
-//            Socket = socket;
-//            CommandQueue = new AsyncQueue<ICommand>();
+        public PlayerSocketConnection(Socket socket)
+        {
+            Socket = socket;
+            CommandQueue = new AsyncQueue<ICommand>();
 
-//            _cancellationTokenSource = new CancellationTokenSource();
-//        }
+            _cancellationTokenSource = new CancellationTokenSource();
+            IsConnected = true;
+        }
 
-//        public async Task Init()
-//        {
-//            Player.ClientSession = ClientSessionTemplate.CreateEntity(
-//              "AI5q8XLJibe9vwx50OoS4A6nHai3oNd6U3ct96535B3azEoHfWKXQYOV6CbJfXUOBAoUvDzVbJGiOXPED9k0jAM=:AQAB"
-//            );
+        public async Task Init()
+        {
+            Player.ClientSession = ClientSessionTemplate.CreateEntity(
+              "AI5q8XLJibe9vwx50OoS4A6nHai3oNd6U3ct96535B3azEoHfWKXQYOV6CbJfXUOBAoUvDzVbJGiOXPED9k0jAM=:AQAB"
+            );
 
-//            await SendCommands(new InitTimeCommand());
-//            Player.ShareEntities(Player.ClientSession);
-//        }
+            await SendCommands(new InitTimeCommand());
+            Player.ShareEntities(Player.ClientSession);
+        }
 
-//        public async Task ReceivePackets()
-//        {
-//            byte[] buffer = GC.AllocateArray<byte>(4096, true);
-//            Memory<byte> memory = buffer.AsMemory();
+        public async Task ReceivePackets()
+        {
+            byte[] buffer = GC.AllocateArray<byte>(4096, true);
+            Memory<byte> memory = buffer.AsMemory();
 
-//            while (true)
-//            {
-//                try
-//                {
-//                    int bytesReceived = await Socket.ReceiveAsync(memory, SocketFlags.None, _cancellationTokenSource.Token);
-//                    if (bytesReceived == 0)
-//                    {
-//                        Logger.WithPlayer(Player).Verbose(
-//                          "Lost connection"
-//                        );
-//                        _cancellationTokenSource.Cancel();
-//                        break;
-//                    }
+            while (!_cancellationTokenSource.IsCancellationRequested)
+            {
+                try
+                {
+                    int bytesReceived = await Socket.ReceiveAsync(memory, SocketFlags.None, _cancellationTokenSource.Token);
+                    if (bytesReceived == 0)
+                    {
+                        Logger.WithPlayer(Player).Verbose(
+                          "Lost connection"
+                        );
+                        _cancellationTokenSource.Cancel();
+                        break;
+                    }
 
-//                    // Logger.WithPlayer(Player).Verbose(
-//                    //   "Received: {@Data}",
-//                    //   memory[..bytesReceived].ToArray()
-//                    // );
+                    await using MemoryStream stream = new MemoryStream(buffer);
+                    using BinaryReader reader = new BigEndianBinaryReader(stream);
+                    DataDecoder decoder = new DataDecoder(reader);
 
-//                    await using MemoryStream stream = new MemoryStream(buffer);
-//                    using BinaryReader reader = new BigEndianBinaryReader(stream);
-//                    DataDecoder decoder = new DataDecoder(reader);
+                    List<ICommand> commands = await decoder.DecodeCommands(Player);
 
-//                    List<ICommand> commands = await decoder.DecodeCommands(Player);
+                    foreach (ICommand command in commands)
+                    {
+                        await command.OnReceive(Player);
+                    }
 
-//                    foreach (ICommand command in commands)
-//                    {
-//                        await command.OnReceive(Player);
-//                    }
+                    Logger.WithPlayer(Player).Verbose(
+                      "Received commands: {{\n{Commands}\n}}",
+                      string.Join(",\n", commands.Select((command) => $"    {command}"))
+                    );
+                }
+                catch (InvalidPacketHeaderException exception)
+                {
+                    Logger.WithPlayer(Player).Warning(
+                      "Invalid packet header. Expected data: {ExpectedData}. Actual data: {ActualData}. Is HTTP request: {IsHttp}",
+                      InvalidPacketHeaderException.GetHex(exception.ExpectedData),
+                      InvalidPacketHeaderException.GetHex(exception.ActualData),
+                      exception.IsHttp
+                    );
 
-//                    Logger.WithPlayer(Player).Verbose(
-//                      "Received commands: {{\n{Commands}\n}}",
-//                      string.Join(",\n", commands.Select((command) => $"    {command}"))
-//                    );
-//                }
-//                catch (InvalidPacketHeaderException exception)
-//                {
-//                    Logger.WithPlayer(Player).Warning(
-//                      "Invalid packet header. Expected data: {ExpectedData}. Actual data: {ActualData}. Is HTTP request: {IsHttp}",
-//                      InvalidPacketHeaderException.GetHex(exception.ExpectedData),
-//                      InvalidPacketHeaderException.GetHex(exception.ActualData),
-//                      exception.IsHttp
-//                    );
+                    if (exception.IsHttp)
+                    {
+                        string content = "<html>\n" +
+                                         "<head>\n" +
+                                         "  <meta charset=\"utf-8\">\n" +
+                                         "  <title>Araumi</title>\n" +
+                                         "</head>\n" +
+                                         "<body>\n" +
+                                         "  <h1>400 Bad Request</h1>\n" +
+                                         "  <h2>" +
+                                         "    You tried to access Araumi gameserver instead of the static server.<br />" +
+                                         "    If you weren't expecting this error, contact project administration" +
+                                         "  </h2>\n" +
+                                         "  <hr />\n" +
+                                         "  <h3>Araumi, <a href=\"https://github.com/Araumi-sh/Araumi\" target=\"_blank\" rel=\"noopener\">https://github.com/Araumi-sh/Araumi</a></h3>" +
+                                         "</body>\n" +
+                                         "</html>";
+                        string response = $"HTTP/1.1 400 Bad Request\r\n" +
+                                          $"Server: Araumi\r\n" +
+                                          $"Connection: close\r\n" +
+                                          $"Content-Length: {content.Length}\r\n" +
+                                          $"\r\n" +
+                                          $"{content}";
 
-//                    if (exception.IsHttp)
-//                    {
-//                        // Send user-friendly error message
+                        await Socket.SendAsync(Encoding.UTF8.GetBytes(response), SocketFlags.None);
+                        Socket.Shutdown(SocketShutdown.Both);
+                        Socket.Close();
 
-//                        string content = "<html>\n" +
-//                                         "<head>\n" +
-//                                         "  <meta charset=\"utf-8\">\n" +
-//                                         "  <title>Araumi</title>\n" +
-//                                         "</head>\n" +
-//                                         "<body>\n" +
-//                                         "  <h1>400 Bad Request</h1>\n" +
-//                                         "  <h2>" +
-//                                         "    You tried to access Araumi game server instead of the static server.<br />" +
-//                                         "    If you weren't expecting this error, contact project administration" +
-//                                         "  </h2>\n" +
-//                                         "  <hr />\n" +
-//                                         "  <h3>Araumi, <a href=\"https://github.com/Araumi-sh/Araumi\" target=\"_blank\" rel=\"noopener\">https://github.com/Araumi-sh/Araumi</a></h3>" +
-//                                         "</body>\n" +
-//                                         "</html>";
-//                        string response = $"HTTP/1.1 400 Bad Request\r\n" +
-//                                          $"Server: Araumi\r\n" +
-//                                          $"Connection: close\r\n" +
-//                                          $"Content-Length: {content.Length}\r\n" +
-//                                          $"\r\n" +
-//                                          $"{content}";
+                        break;
+                    }
+                }
+                catch (MissingTypeUidException exception)
+                {
+                    Logger.WithPlayer(Player).Warning(
+                      "Missing TypeUid attribute for type {Type}",
+                      exception.Type
+                    );
+                }
+                catch (UnknownTypeUidException exception)
+                {
+                    Logger.WithPlayer(Player).Warning(
+                      "Unknown TypeUid: {TypeUid}",
+                      exception.TypeUid
+                    );
+                }
+                catch (Exception exception)
+                {
+                    Logger.Error(
+                      exception,
+                      "Unexpected exception"
+                    );
+                    break;
+                }
+            }
+        }
 
-//                        await Socket.SendAsync(Encoding.UTF8.GetBytes(response), SocketFlags.None);
-//                        Socket.Shutdown(SocketShutdown.Both);
-//                        Socket.Close();
+        public async Task SendPackets()
+        {
+            await foreach (ICommand command in CommandQueue)
+            {
+                await SendCommands(command);
+            }
+        }
 
-//                        break;
-//                    }
-//                }
-//                catch (MissingTypeUidException exception)
-//                {
-//                    Logger.WithPlayer(Player).Warning(
-//                      "Missing TypeUid attribute for type {Type}",
-//                      exception.Type
-//                    );
-//                }
-//                catch (UnknownTypeUidException exception)
-//                {
-//                    Logger.WithPlayer(Player).Warning(
-//                      "Unknown TypeUid: {TypeUid}",
-//                      exception.TypeUid
-//                    );
-//                }
-//                catch (Exception exception)
-//                {
-//                    Logger.Error(
-//                      exception,
-//                      "Unexpected exception"
-//                    );
-//                    break;
-//                }
-//            }
-//        }
+        public void QueueCommands(params ICommand[] commands)
+        {
+            foreach (ICommand command in commands)
+            {
+                CommandQueue.Enqueue(command);
+            }
+        }
 
-//        public async Task SendPackets()
-//        {
-//            await foreach (ICommand command in CommandQueue)
-//            {
-//                await SendCommands(command);
-//            }
-//        }
+        public async Task SendCommands(params ICommand[] commands)
+        {
+            await using MemoryStream stream = new MemoryStream();
+            await using BinaryWriter writer = new BigEndianBinaryWriter(stream);
+            DataEncoder encoder = new DataEncoder(writer);
 
-//        public void QueueCommands(params ICommand[] commands)
-//        {
-//            foreach (ICommand command in commands)
-//            {
-//                CommandQueue.Enqueue(command);
-//            }
-//        }
+            await encoder.EncodeCommands(commands);
 
-//        public async Task SendCommands(params ICommand[] commands)
-//        {
-//            await using MemoryStream stream = new MemoryStream();
-//            await using BinaryWriter writer = new BigEndianBinaryWriter(stream);
-//            DataEncoder encoder = new DataEncoder(writer);
+            writer.Flush();
 
-//            await encoder.EncodeCommands(commands);
+            Logger.Verbose(
+              "Sending commands: {{\n{Commands}\n}}",
+              string.Join(",\n", commands.Select((command) => $"    {command}"))
+            );
 
-//            writer.Flush();
-
-//            Logger.Verbose(
-//              "Sending commands: {{\n{Commands}\n}}",
-//              string.Join(",\n", commands.Select((command) => $"    {command}"))
-//            );
-
-//            // Logger.Verbose("Sending {@Data}...", stream.ToArray());
-
-//            await Socket.SendAsync(stream.ToArray(), SocketFlags.None, _cancellationTokenSource.Token);
-//        }
-//    }
-//}
+            await Socket.SendAsync(stream.ToArray(), SocketFlags.None, _cancellationTokenSource.Token);
+        }
+    }
+}

--- a/UTanksServer/Services/Servers/Game/GameServer.cs
+++ b/UTanksServer/Services/Servers/Game/GameServer.cs
@@ -68,19 +68,18 @@ namespace UTanksServer.Services.Servers.Game {
       Socket clientSocket = await _socket.AcceptAsync();
 
       Player player = new Player();
-            //PlayerSocketConnection connection = new PlayerSocketConnection(clientSocket);
+      PlayerSocketConnection connection = new PlayerSocketConnection(clientSocket);
 
-            //player.Connection = connection;
-            //connection.Player = player;
+      player.Connection = connection;
+      connection.Player = player;
 
-            //_clients.Add(connection);
+      _clients.Add(connection);
 
-            //Logger.WithPlayer(connection.Player).Verbose(
-            //  "Accepted socket"
-            //);
+      Logger.WithPlayer(connection.Player).Verbose(
+        "Accepted socket"
+      );
 
-            //return connection;
-            return null;
+      return connection;
     }
   }
 }


### PR DESCRIPTION
## Summary
- implement the missing `PlayerSocketConnection`
- hook up client acceptance in `GameServer`
- add async system loop control and stop method
- run systems sequentially to avoid huge task creation
- wait asynchronously for team component
- refactor lock helpers to avoid busy waiting
- read DB credentials from `Config/Database.json`
- add configuration example and basic README

## Testing
- `dotnet build UTanksServer/UTanksServer.csproj` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6864f12677f883318a53ef9b49728aa2