### PR TITLE
Implement AI bot management system with console commands

### DIFF
--- a/UTanksServer/ECS/Components/Battle/BotComponent/AutoMoveComponent.cs
+++ b/UTanksServer/ECS/Components/Battle/BotComponent/AutoMoveComponent.cs
@@ -1,0 +1,68 @@
+using System;
+using UTanksServer.ECS.Components.Battle.Location;
+using UTanksServer.ECS.ECSCore;
+using UTanksServer.ECS.Events.Battle.TankEvents;
+using UTanksServer.Network.NetworkEvents.FastGameEvents;
+using UTanksServer.ECS.Types.Battle;
+
+namespace UTanksServer.ECS.Components.Battle.BotComponent
+{
+    [TypeUid(223899603046642000)]
+    public class AutoMoveComponent : TimerComponent
+    {
+        static public new long Id { get; set; }
+        static public new System.Collections.Generic.List<System.Action> StaticOnChangeHandlers { get; set; }
+        private readonly Random random = new Random();
+        public float MovePeriod;
+        public AutoMoveComponent() { }
+        public AutoMoveComponent(float period)
+        {
+            MovePeriod = period;
+            onEnd = (entity, timerComp) =>
+            {
+                try
+                {
+                    var world = entity.GetComponent<WorldPositionComponent>().WorldPoint.Position;
+                    world.x += (float)(random.NextDouble() * 2 - 1);
+                    world.z += (float)(random.NextDouble() * 2 - 1);
+                    var moveEvent = new MoveCommandEvent()
+                    {
+                        EntityOwnerId = entity.instanceId,
+                        position = world,
+                        velocity = new Vector3S(),
+                        angularVelocity = new Vector3S(),
+                        rotation = new QuaternionS(),
+                        turretRotation = new QuaternionS(),
+                        WeaponRotation = 0,
+                        TankMoveControl = 0,
+                        TankTurnControl = 0,
+                        WeaponRotationControl = 0,
+                        ClientTime = 0
+                    };
+                    moveEvent.cachedRawEvent = new RawMovementEvent()
+                    {
+                        packetId = 0,
+                        PlayerEntityId = entity.instanceId,
+                        position = moveEvent.position,
+                        velocity = moveEvent.velocity,
+                        angularVelocity = moveEvent.angularVelocity,
+                        rotation = moveEvent.rotation,
+                        turretRotation = moveEvent.turretRotation,
+                        WeaponRotation = moveEvent.WeaponRotation,
+                        TankMoveControl = moveEvent.TankMoveControl,
+                        TankTurnControl = moveEvent.TankTurnControl,
+                        WeaponRotationControl = moveEvent.WeaponRotationControl,
+                        ClientTime = moveEvent.ClientTime
+                    };
+                    ManagerScope.eventManager.OnEventAdd(moveEvent);
+                }
+                catch { }
+            };
+        }
+        public override void OnAdded(ECSEntity entity)
+        {
+            base.OnAdded(entity);
+            TimerStart(MovePeriod, ownerEntity, true, true);
+        }
+    }
+}

--- a/UTanksServer/Program.cs
+++ b/UTanksServer/Program.cs
@@ -250,7 +250,7 @@ namespace UTanksServer
                             "\n  addserver - Create login credentials to the DB" +
                             "\n  ld - loadbots" +
                             "\n  lda - loadbotsall" +
-                            "\n  lda - loadbotsall" +
+                            "\n  bot - manage ai bots" +
                             "\n  tb - testbattle" +
                             "\n  JTServer - Modify the JTServer process");
                         break;
@@ -271,6 +271,56 @@ namespace UTanksServer
                             all++;
                         });
                         Console.WriteLine("All online" + all.ToString() + "\nIn battles: " + inbattle.ToString());
+                        break;
+                    case "bot":
+                        if (input.Length < 2)
+                        {
+                            Console.WriteLine("bot commands: add <battleId> <teamId> <count>, remove <botId>, list");
+                            break;
+                        }
+        
+                        switch (input[1].ToLower())
+                        {
+                            case "add":
+                                if (input.Length < 5)
+                                {
+                                    Console.WriteLine("Syntax: bot add <battleId> <teamId> <count>");
+                                    break;
+                                }
+                                try
+                                {
+                                    long battleId = long.Parse(input[2]);
+                                    long teamId = long.Parse(input[3]);
+                                    int count = int.Parse(input[4]);
+                                    BotService.AddBots(battleId, teamId, count);
+                                }
+                                catch
+                                {
+                                    Console.WriteLine("Invalid parameters");
+                                }
+                                break;
+                            case "remove":
+                                if (input.Length < 3)
+                                {
+                                    Console.WriteLine("Syntax: bot remove <botId>");
+                                    break;
+                                }
+                                if (long.TryParse(input[2], out long botId))
+                                {
+                                    if (!BotService.RemoveBot(botId))
+                                        Console.WriteLine("Bot not found");
+                                }
+                                else
+                                    Console.WriteLine("Invalid bot id");
+                                break;
+                            case "list":
+                                foreach (var id in BotService.ListBots())
+                                    Console.WriteLine(id);
+                                break;
+                            default:
+                                Console.WriteLine("bot commands: add <battleId> <teamId> <count>, remove <botId>, list");
+                                break;
+                        }
                         break;
                     case "ld":
                         if (true)

--- a/UTanksServer/Services/BotService.cs
+++ b/UTanksServer/Services/BotService.cs
@@ -1,0 +1,119 @@
+using System;
+using System.Collections.Concurrent;
+using System.Threading;
+using System.Linq;
+using UTanksServer.Database;
+using UTanksServer.Database.Databases;
+using UTanksServer.ECS.Components;
+using UTanksServer.ECS.Components.Battle;
+using UTanksServer.ECS.Components.Battle.BattleComponents;
+using UTanksServer.ECS.Components.Battle.BotComponent;
+using UTanksServer.ECS.ECSCore;
+using UTanksServer.ECS.Events.Battle;
+using UTanksServer.ECS.Templates.User;
+using UTanksServer.Extensions;
+
+namespace UTanksServer.Services
+{
+    public static class BotService
+    {
+        static readonly ConcurrentDictionary<long, ECSEntity> Bots = new ConcurrentDictionary<long, ECSEntity>();
+        public static void AddBots(long battleId, long teamId, int count)
+        {
+            if (!ManagerScope.entityManager.EntityStorage.TryGetValue(battleId, out var battle))
+            {
+                Console.WriteLine("battle not found");
+                return;
+            }
+            if (!ManagerScope.entityManager.EntityStorage.TryGetValue(teamId, out var team))
+            {
+                Console.WriteLine("team not found");
+                return;
+            }
+            for (int i = 0; i < count; i++)
+            {
+                AddBotInternal(battle, team);
+            }
+        }
+        private static void AddBotInternal(ECSEntity battle, ECSEntity team)
+        {
+            var userNetwork = new Network.Simple.Net.Server.User() { PlayerEntityId = Guid.NewGuid().GuidToLong() };
+            var random = new Random();
+            var userrow = new UserRow()
+            {
+                ActiveChatBanEndTime = 0,
+                Clan = -1,
+                Crystalls = 100000,
+                Email = random.RandomString(10),
+                EmailVerified = true,
+                GarageJSONData = DatabaseQuery.NewbieAccountGarage,
+                GlobalScore = 193000,
+                HardwareId = random.RandomString(10),
+                HardwareToken = random.RandomString(10),
+                id = -1,
+                Karma = 0,
+                LastDatetimeGetDailyBonus = 0,
+                LastIp = "127.0.0.1",
+                Password = "c20ad4d76fe97759aa27a0c99bff6710",
+                Rank = 14,
+                RankScore = 1000,
+                RegistrationDate = -1,
+                TermlessBan = false,
+                UserGroup = "admin",
+                UserLocation = "en",
+                Username = "bot_" + random.RandomString(8)
+            };
+            var entityUser = new UserTemplate().CreateEntity(userrow, userNetwork.PlayerEntityId);
+            ManagerScope.eventManager.OnEventAdd(new UserLogged()
+            {
+                networkSocket = userNetwork,
+                EntityOwnerId = userNetwork.PlayerEntityId,
+                userRelogin = false,
+                userEntity = entityUser,
+                actionAfterLoggin = (entity) =>
+                {
+                    ManagerScope.eventManager.OnEventAdd(new EnterToBattleEvent()
+                    {
+                        BattleId = battle.instanceId,
+                        TeamInstanceId = team.instanceId,
+                        EntityOwnerId = entity.instanceId
+                    });
+                    Thread.Sleep(100);
+                    ManagerScope.eventManager.OnEventAdd(new BattleLoadedEvent()
+                    {
+                        BattleId = battle.instanceId,
+                        TeamInstanceId = team.instanceId,
+                        EntityOwnerId = entity.instanceId
+                    });
+                    Thread.Sleep(100);
+                    entity.AddComponent(new AutoSmokyComponent(5f).SetGlobalComponentGroup());
+                    entity.AddComponent(new AutoMoveComponent(1f).SetGlobalComponentGroup());
+                    Bots[entity.instanceId] = entity;
+                }
+            });
+        }
+        public static bool RemoveBot(long botId)
+        {
+            if (Bots.TryRemove(botId, out var entity))
+            {
+                if (entity.HasComponent(BattleOwnerComponent.Id))
+                {
+                    var owner = entity.GetComponent<BattleOwnerComponent>();
+                    ManagerScope.eventManager.OnEventAdd(new LeaveFromBattleEvent()
+                    {
+                        BattleId = owner.BattleInstanceId,
+                        TeamInstanceId = entity.GetComponent<TeamComponent>().instanceId,
+                        EntityOwnerId = entity.instanceId
+                    });
+                }
+                ManagerScope.entityManager.OnRemoveEntity(entity);
+                return true;
+            }
+            return false;
+        }
+        public static long[] ListBots()
+        {
+            return Bots.Keys.ToArray();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add AutoMoveComponent to give bots simple movement AI
- Introduce BotService for adding, listing and removing bots
- Extend console with `bot add`, `bot remove`, and `bot list` commands

## Testing
- `dotnet build UTanksServer/UTanksServer.csproj` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68a1b22ab05083318e080b16da3c356e