### PR TITLE
Persist battles in database with cooldown and console commands

### DIFF
--- a/UTanksServer/ECS/Components/User/BattleCreationCooldownComponent.cs
+++ b/UTanksServer/ECS/Components/User/BattleCreationCooldownComponent.cs
@@ -1,0 +1,13 @@
+using UTanksServer.ECS.ECSCore;
+
+namespace UTanksServer.ECS.Components.User
+{
+    [TypeUid(449812176345098500)]
+    public class BattleCreationCooldownComponent : ECSComponent
+    {
+        public static new long Id { get; set; }
+        public static new System.Collections.Generic.List<System.Action> StaticOnChangeHandlers { get; set; }
+
+        public long LastCreationUnixTimeSeconds;
+    }
+}

--- a/UTanksServer/ECS/Systems/Battles/BattleLifetimeSystem.cs
+++ b/UTanksServer/ECS/Systems/Battles/BattleLifetimeSystem.cs
@@ -3,6 +3,10 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Core;
+using Newtonsoft.Json;
+using UTanksServer.Database.Databases;
+using UTanksServer.Database.Databases.ServerTables;
 using UTanksServer.ECS.Components;
 using UTanksServer.ECS.Components.Battle;
 using UTanksServer.ECS.Components.Battle.BattleComponents;
@@ -77,16 +81,148 @@ namespace UTanksServer.ECS.Systems.Battles
                 ManagerScope.entityManager.OnRemoveEntity(ManagerScope.entityManager.EntityStorage[gameplayEntity]);
             }
             ManagerScope.entityManager.OnRemoveEntity(battleEntity);
+            if (ServerDatabase.Battles != null)
+            {
+                _ = Task.Run(async () =>
+                {
+                    try
+                    {
+                        await ServerDatabase.Battles.Remove(battleEntity.instanceId);
+                    }
+                    catch (Exception ex)
+                    {
+                        Logger.LogError($"Failed to remove battle {battleEntity.instanceId} metadata: {ex.Message}", "BattleDB");
+                    }
+                });
+            }
         }
 
         public static void CreateBattle(CreateBattleEvent createBattleEvent)
         {
-            foreach(var battleEntity in new BattleTemplate().CreateBattleEntities(createBattleEvent))
+            if (!ManagerScope.entityManager.EntityStorage.TryGetValue(createBattleEvent.EntityOwnerId, out var ownerEntity))
             {
-                ManagerScope.entityManager.OnAddNewEntity(battleEntity);
-                battleEntity.GetComponent<BattleComponent>(BattleComponent.Id).MarkAsChanged();
-                //battleEntity.GetComponent<BattleSimpleInfoComponent>().MarkAsChanged(true);
+                Logger.LogWarn($"Battle creation request ignored. Owner entity '{createBattleEvent.EntityOwnerId}' not found.", "Battle");
+                return;
             }
+
+            var cooldown = ownerEntity.TryGetComponent<BattleCreationCooldownComponent>();
+            var nowSeconds = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+            if (cooldown != null && cooldown.LastCreationUnixTimeSeconds > 0)
+            {
+                var elapsed = nowSeconds - cooldown.LastCreationUnixTimeSeconds;
+                if (elapsed < 30)
+                {
+                    Logger.LogWarn($"Player {ownerEntity.instanceId} attempted to create a battle before cooldown expired. {30 - elapsed} seconds remaining.", "Battle");
+                    return;
+                }
+            }
+
+            var createdEntities = new BattleTemplate().CreateBattleEntities(createBattleEvent);
+            if (createdEntities.Count == 0)
+                return;
+
+            ECSEntity battleEntity = null;
+            foreach (var entity in createdEntities)
+            {
+                ManagerScope.entityManager.OnAddNewEntity(entity);
+                if (entity.HasComponent(BattleComponent.Id))
+                {
+                    battleEntity = entity;
+                    entity.GetComponent<BattleComponent>(BattleComponent.Id).MarkAsChanged();
+                }
+            }
+
+            if (battleEntity == null)
+                return;
+
+            ownerEntity.AddOrChangeComponent(new BattleCreationCooldownComponent()
+            {
+                LastCreationUnixTimeSeconds = nowSeconds
+            });
+
+            SaveBattleToDatabase(battleEntity, createBattleEvent, nowSeconds);
+        }
+
+        static void SaveBattleToDatabase(ECSEntity battleEntity, CreateBattleEvent createBattleEvent, long createdAt)
+        {
+            if (ServerDatabase.Battles == null)
+                return;
+
+            var battleComponent = battleEntity.GetComponent<BattleComponent>(BattleComponent.Id);
+            var parametersPayload = new
+            {
+                createBattleEvent.BattleCustomName,
+                createBattleEvent.BattleRealName,
+                createBattleEvent.GameMapGroupName,
+                createBattleEvent.MapPath,
+                createBattleEvent.MapModel,
+                createBattleEvent.MapConfigPath,
+                createBattleEvent.MaxPlayers,
+                createBattleEvent.BattleTimeMinutes,
+                createBattleEvent.BattleWinGoalValue,
+                createBattleEvent.MinimalPlayerRankValue,
+                createBattleEvent.MaximalPlayerRankValue,
+                createBattleEvent.WeatherMode,
+                createBattleEvent.TimeMode,
+                createBattleEvent.BattleMode,
+                createBattleEvent.ListOfAcceptedConfigPathWeapon,
+                createBattleEvent.ListOfAcceptedConfigPathHull,
+                createBattleEvent.isProBattle,
+                createBattleEvent.isClosedBattle,
+                createBattleEvent.isParkourBattle,
+                createBattleEvent.isTournamentBattle,
+                createBattleEvent.enableUnlimitedUserSupply,
+                createBattleEvent.enableSuperDrop,
+                createBattleEvent.enableAutoPeaceOnSuperDrop,
+                createBattleEvent.enableMicroUpgrade,
+                createBattleEvent.enableDressingUp,
+                createBattleEvent.dressingUpTimeoutSeconds,
+                createBattleEvent.enableSupplyDrop,
+                createBattleEvent.enableCrystalDrop,
+                createBattleEvent.enablePlayerSupplies,
+                createBattleEvent.enablePlayerAutoBalance,
+                createBattleEvent.enableBattleAutoEnding,
+                createBattleEvent.enableTeamKilling,
+                createBattleEvent.enableResists,
+                createBattleEvent.enableModules,
+                createBattleEvent.enablePlayerSupplySeparation,
+                createBattleEvent.enableSupplyCooldown,
+                createBattleEvent.LuminosityStrength,
+                createBattleEvent.DamageScalingCoeficient,
+                createBattleEvent.HealthScalingCoeficient,
+                createBattleEvent.GravityScaling,
+                createBattleEvent.MassScaling,
+                createBattleEvent.isTestBoxBattle,
+                createBattleEvent.isCheatersBattle
+            };
+
+            var dbRow = new BattleDbRow
+            {
+                BattleId = battleEntity.instanceId,
+                CustomName = battleComponent.BattleCustomName,
+                RealName = battleComponent.BattleRealName,
+                MapGroup = createBattleEvent.GameMapGroupName,
+                MapPath = battleComponent.MapPath,
+                Mode = battleComponent.BattleMode,
+                OwnerEntityId = createBattleEvent.EntityOwnerId,
+                MaxPlayers = battleComponent.MaxPlayers,
+                MinRank = battleComponent.MinimalPlayerRankValue,
+                MaxRank = battleComponent.MaximalPlayerRankValue,
+                CreatedAt = createdAt,
+                ParametersJson = JsonConvert.SerializeObject(parametersPayload)
+            };
+
+            _ = Task.Run(async () =>
+            {
+                try
+                {
+                    await ServerDatabase.Battles.Upsert(dbRow);
+                }
+                catch (Exception ex)
+                {
+                    Logger.LogError($"Failed to persist battle {battleEntity.instanceId} metadata: {ex.Message}", "BattleDB");
+                }
+            });
         }
 
         public static void BattleEnd(BattleEndEvent battleEndEvent)

--- a/UTanksServer/Lobby/Databases/ServerDatabase.cs
+++ b/UTanksServer/Lobby/Databases/ServerDatabase.cs
@@ -9,6 +9,7 @@ namespace UTanksServer.Database.Databases {
     public static class ServerDatabase {
         public static SQLiteConnection Connection;
         public static Servers Servers;
+        public static Battles Battles;
 
         public static async void Load() {
             string connectionString = "URI=file:" + Path.Join(GlobalProgramState.ConfigDir, "Servers.db");
@@ -16,10 +17,12 @@ namespace UTanksServer.Database.Databases {
             Connection = new SQLiteConnection(connectionString);
             await Connection.OpenAsync();
             Servers = await new Servers().Init();
+            Battles = await new Battles().Init();
         }
 
         public static async void Dispose() {
             Servers = null;
+            Battles = null;
             await Connection.CloseAsync();
         }
     }

--- a/UTanksServer/Lobby/Databases/ServerTables/Battles.cs
+++ b/UTanksServer/Lobby/Databases/ServerTables/Battles.cs
@@ -1,0 +1,147 @@
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Data.Common;
+using System.Data.SQLite;
+using System.Threading.Tasks;
+using Core;
+using UTanksServer.Services;
+
+namespace UTanksServer.Database.Databases.ServerTables
+{
+    public class Battles
+    {
+        public async Task<Battles> Init()
+        {
+            using (var request = new SQLiteCommand(
+                "CREATE TABLE IF NOT EXISTS `battles` (" +
+                "  `battle_id` INTEGER PRIMARY KEY," +
+                "  `custom_name` TEXT NOT NULL," +
+                "  `real_name` TEXT NOT NULL," +
+                "  `map_group` TEXT NOT NULL," +
+                "  `map_path` TEXT NOT NULL," +
+                "  `mode` TEXT NOT NULL," +
+                "  `owner_entity_id` INTEGER NOT NULL," +
+                "  `max_players` INTEGER NOT NULL," +
+                "  `min_rank` INTEGER NOT NULL," +
+                "  `max_rank` INTEGER NOT NULL," +
+                "  `created_at` INTEGER NOT NULL," +
+                "  `parameters_json` TEXT NOT NULL" +
+                ");",
+                ServerDatabase.Connection))
+            {
+                ServerMonitor.RegisterDbWrite();
+                await request.ExecuteNonQueryAsync();
+            }
+
+            Logger.Log("Table 'ServerDatabase.battles' initilized", "init");
+            return this;
+        }
+
+        public async Task<bool> Upsert(BattleDbRow data)
+        {
+            using (var request = new SQLiteCommand(
+                "INSERT OR REPLACE INTO battles (battle_id, custom_name, real_name, map_group, map_path, mode, owner_entity_id, max_players, min_rank, max_rank, created_at, parameters_json) " +
+                "VALUES (@battleId, @customName, @realName, @mapGroup, @mapPath, @mode, @ownerEntityId, @maxPlayers, @minRank, @maxRank, @createdAt, @parametersJson);",
+                ServerDatabase.Connection))
+            {
+                request.Parameters.AddWithValue("@battleId", data.BattleId);
+                request.Parameters.AddWithValue("@customName", data.CustomName);
+                request.Parameters.AddWithValue("@realName", data.RealName);
+                request.Parameters.AddWithValue("@mapGroup", data.MapGroup);
+                request.Parameters.AddWithValue("@mapPath", data.MapPath);
+                request.Parameters.AddWithValue("@mode", data.Mode);
+                request.Parameters.AddWithValue("@ownerEntityId", data.OwnerEntityId);
+                request.Parameters.AddWithValue("@maxPlayers", data.MaxPlayers);
+                request.Parameters.AddWithValue("@minRank", data.MinRank);
+                request.Parameters.AddWithValue("@maxRank", data.MaxRank);
+                request.Parameters.AddWithValue("@createdAt", data.CreatedAt);
+                request.Parameters.AddWithValue("@parametersJson", data.ParametersJson);
+
+                ServerMonitor.RegisterDbWrite();
+                return await request.ExecuteNonQueryAsync() > 0;
+            }
+        }
+
+        public async Task<bool> Remove(long battleId)
+        {
+            using (var request = new SQLiteCommand(
+                "DELETE FROM battles WHERE battle_id = @battleId;",
+                ServerDatabase.Connection))
+            {
+                request.Parameters.AddWithValue("@battleId", battleId);
+
+                ServerMonitor.RegisterDbWrite();
+                return await request.ExecuteNonQueryAsync() > 0;
+            }
+        }
+
+        public async Task<int> RemoveByMapName(string mapName)
+        {
+            using (var request = new SQLiteCommand(
+                "DELETE FROM battles WHERE lower(map_group) = lower(@mapName) OR lower(real_name) = lower(@mapName) OR lower(custom_name) = lower(@mapName);",
+                ServerDatabase.Connection))
+            {
+                request.Parameters.AddWithValue("@mapName", mapName);
+
+                ServerMonitor.RegisterDbWrite();
+                return await request.ExecuteNonQueryAsync();
+            }
+        }
+
+        public async Task<List<BattleDbRow>> List()
+        {
+            using (var request = new SQLiteCommand(
+                "SELECT battle_id, custom_name, real_name, map_group, map_path, mode, owner_entity_id, max_players, min_rank, max_rank, created_at, parameters_json FROM battles ORDER BY created_at DESC;",
+                ServerDatabase.Connection))
+            {
+                var result = new List<BattleDbRow>();
+                ServerMonitor.RegisterDbRead();
+                using (DbDataReader reader = await request.ExecuteReaderAsync(CommandBehavior.Default))
+                {
+                    while (await reader.ReadAsync())
+                    {
+                        result.Add(ReadRow(reader));
+                    }
+                }
+
+                return result;
+            }
+        }
+
+        private static BattleDbRow ReadRow(DbDataReader reader)
+        {
+            return new BattleDbRow
+            {
+                BattleId = reader.GetInt64(reader.GetOrdinal("battle_id")),
+                CustomName = reader.GetString(reader.GetOrdinal("custom_name")),
+                RealName = reader.GetString(reader.GetOrdinal("real_name")),
+                MapGroup = reader.GetString(reader.GetOrdinal("map_group")),
+                MapPath = reader.GetString(reader.GetOrdinal("map_path")),
+                Mode = reader.GetString(reader.GetOrdinal("mode")),
+                OwnerEntityId = reader.GetInt64(reader.GetOrdinal("owner_entity_id")),
+                MaxPlayers = reader.GetInt32(reader.GetOrdinal("max_players")),
+                MinRank = reader.GetInt32(reader.GetOrdinal("min_rank")),
+                MaxRank = reader.GetInt32(reader.GetOrdinal("max_rank")),
+                CreatedAt = reader.GetInt64(reader.GetOrdinal("created_at")),
+                ParametersJson = reader.GetString(reader.GetOrdinal("parameters_json"))
+            };
+        }
+    }
+
+    public struct BattleDbRow
+    {
+        public long BattleId;
+        public string CustomName;
+        public string RealName;
+        public string MapGroup;
+        public string MapPath;
+        public string Mode;
+        public long OwnerEntityId;
+        public int MaxPlayers;
+        public int MinRank;
+        public int MaxRank;
+        public long CreatedAt;
+        public string ParametersJson;
+    }
+}

--- a/UTanksServer/Program.cs
+++ b/UTanksServer/Program.cs
@@ -111,7 +111,7 @@ namespace UTanksServer
             //ZipExt.DecompressToDirectory(@"L:\UTanksServer\UTanksServer\bin\Debug\net5.0\Data\zippedconfig.zip", @"L:\UTanksServer\UTanksServer\bin\Debug\net5.0\Data\test", (prog) => { });
 #endregion
             Logger.Log("Config loaded!", "init");
-            //ServerDatabase.Load();
+            ServerDatabase.Load();
             ConstantService.Initialize();     
             //GlobalCachingSerialization.Init();//serialization not work heh
             UserDatabase.Load();
@@ -157,7 +157,13 @@ namespace UTanksServer
                 {
                     case "exit":
                         Networking.Stop();
-                        return;              
+                        return;
+                    case "restart":
+                        if (UTServer.Instance != null && UTServer.Instance.IsRunning)
+                            UTServer.Instance.Destroy(true);
+                        else
+                            new UTServer();
+                        break;
                     case "jtserver":
                         if (input.Length >= 2)
                         {
@@ -259,10 +265,62 @@ namespace UTanksServer
                     case "drops":
                         Console.WriteLine("not realized");
                         break;
+                    case "battle":
+                        if (input.Length < 2)
+                        {
+                            Console.WriteLine("battle commands: list");
+                            break;
+                        }
+
+                        switch (input[1].ToLower())
+                        {
+                            case "list":
+                                if (ServerDatabase.Battles == null)
+                                {
+                                    Console.WriteLine("Battle database is not initialized.");
+                                    break;
+                                }
+
+                                var storedBattles = await ServerDatabase.Battles.List();
+                                if (storedBattles.Count == 0)
+                                {
+                                    Console.WriteLine("No battles stored in the database.");
+                                    break;
+                                }
+
+                                foreach (var storedBattle in storedBattles)
+                                {
+                                    Console.WriteLine($"[{storedBattle.BattleId}] {storedBattle.CustomName} - {storedBattle.MapGroup} ({storedBattle.Mode})");
+                                }
+                                break;
+                            default:
+                                Console.WriteLine("battle commands: list");
+                                break;
+                        }
+                        break;
                     case "battles":
                         ManagerScope.entityManager.EntityStorage.Values.Where((x) => x.HasComponent(BattleComponent.Id)).ToList().ForEach(x => {
                             Console.WriteLine(x.instanceId.ToString() + "   " + x.GetComponent< BattleComponent>().BattleCustomName + "   " + x.GetComponent<BattleComponent>().BattleRealName);
                         });
+                        break;
+                    case "del":
+                        if (input.Length < 2)
+                        {
+                            Console.WriteLine("Usage: del <map_name>");
+                            break;
+                        }
+
+                        if (ServerDatabase.Battles == null)
+                        {
+                            Console.WriteLine("Battle database is not initialized.");
+                            break;
+                        }
+
+                        var removedCount = await ServerDatabase.Battles.RemoveByMapName(input[1]);
+                        if (removedCount == 0)
+                            Console.WriteLine($"No stored battles found for map '{input[1]}'.");
+                        else
+                            Console.WriteLine($"Removed {removedCount} stored battle entr{(removedCount == 1 ? "y" : "ies")} for map '{input[1]}'.");
                         break;
                     case "players":
                         int inbattle = 0;


### PR DESCRIPTION
## Summary
- load the server database on startup and add a new battles table for storing battle metadata
- record newly created battles with their parameters, enforce a 30 second owner cooldown, and clear database entries on removal
- add a battle creation cooldown component plus server console commands for restart, listing stored battles, and deleting map entries

## Testing
- dotnet build *(fails: `dotnet` CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc13f02310833180626960a978a3f9