### PR TITLE
Overhaul game server networking pipeline

### DIFF
--- a/UTanksServer/Core/Logging/Logger.cs
+++ b/UTanksServer/Core/Logging/Logger.cs
@@ -1,38 +1,92 @@
 using System;
+using System.Collections.Concurrent;
+using System.Threading;
+using System.Threading.Channels;
+using System.Threading.Tasks;
 
-namespace UTanksServer.Core.Logging
-{
-    internal static class Logger
-    {
-        private static readonly object _lock = new();
+namespace UTanksServer.Core.Logging {
+  internal static class Logger {
+    private static readonly Channel<LogMessage> Channel = System.Threading.Channels.Channel.CreateUnbounded<LogMessage>(new UnboundedChannelOptions {
+      AllowSynchronousContinuations = false,
+      SingleReader = true,
+      SingleWriter = false
+    });
 
-        private static void Write(string type, ConsoleColor color, object content)
-        {
-            lock (_lock)
-            {
-                Console.ForegroundColor = color;
-                Console.WriteLine($"[{DateTime.UtcNow}, {type}] {content}");
-            }
-        }
+    private static readonly Task ProcessingTask;
 
-        private static void DebugWrite(string type, ConsoleColor color, object content)
-        {
-#if DEBUG
-            Write(type, color, content);
-#endif
-        }
-
-        public static void Log(object content) => Write("INFO", ConsoleColor.Gray, content);
-
-        public static void Debug(object content) => DebugWrite("DEBUG", ConsoleColor.DarkGreen, content);
-        public static void Trace(object content)
-        {
-            //if (Server.Instance.Settings.EnableTracing)
-            //    DebugWrite("TRACE", ConsoleColor.DarkGray, content);
-        }
-
-        public static void Warn(object content) => Write("WARN", ConsoleColor.DarkYellow, content);
-
-        public static void Error(object content) => Write("ERROR", ConsoleColor.Red, content);
+    static Logger() {
+      ProcessingTask = Task.Run(ProcessQueueAsync);
     }
+
+    public static void Log(object content) => Enqueue("INFO", ConsoleColor.Gray, content);
+    public static void Debug(object content) => Enqueue("DEBUG", ConsoleColor.DarkGreen, content);
+    public static void Trace(object content) => Enqueue("TRACE", ConsoleColor.DarkGray, content, sample: true);
+    public static void Warn(object content) => Enqueue("WARN", ConsoleColor.DarkYellow, content);
+    public static void Error(object content) => Enqueue("ERROR", ConsoleColor.Red, content);
+
+    private static void Enqueue(string type, ConsoleColor color, object content, bool sample = false) {
+      if(sample && !Sampler.ShouldWrite(type)) {
+        return;
+      }
+
+      Channel.Writer.TryWrite(new LogMessage(type, color, content, DateTime.UtcNow));
+    }
+
+    private static async Task ProcessQueueAsync() {
+      await foreach(LogMessage message in Channel.Reader.ReadAllAsync()) {
+        Write(message);
+      }
+    }
+
+    private static void Write(LogMessage message) {
+      ConsoleColor original = Console.ForegroundColor;
+      try {
+        Console.ForegroundColor = message.Color;
+        Console.WriteLine($"[{message.Timestamp:O}, {message.Type}] {message.Content}");
+      } finally {
+        Console.ForegroundColor = original;
+      }
+    }
+
+    private readonly record struct LogMessage(string Type, ConsoleColor Color, object Content, DateTime Timestamp);
+
+    private static class Sampler {
+      private static readonly ConcurrentDictionary<string, SamplerState> States = new ConcurrentDictionary<string, SamplerState>();
+
+      public static bool ShouldWrite(string key) {
+        SamplerState state = States.GetOrAdd(key, _ => new SamplerState(100, TimeSpan.FromSeconds(1)));
+        return state.TryConsume(DateTime.UtcNow);
+      }
+
+      private sealed class SamplerState {
+        private readonly int _limit;
+        private readonly TimeSpan _period;
+        private int _count;
+        private DateTime _windowStart;
+        private readonly object _sync = new object();
+
+        public SamplerState(int limit, TimeSpan period) {
+          _limit = limit;
+          _period = period;
+          _windowStart = DateTime.UtcNow;
+        }
+
+        public bool TryConsume(DateTime now) {
+          lock(_sync) {
+            if(now - _windowStart > _period) {
+              _windowStart = now;
+              _count = 0;
+            }
+
+            if(_count >= _limit) {
+              return false;
+            }
+
+            _count++;
+            return true;
+          }
+        }
+      }
+    }
+  }
 }

--- a/UTanksServer/Core/Protocol/BufferReader.cs
+++ b/UTanksServer/Core/Protocol/BufferReader.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Buffers.Binary;
+
+namespace UTanksServer.Core.Protocol {
+  public struct BufferReader {
+    private ReadOnlyMemory<byte> _memory;
+    private int _position;
+
+    public BufferReader(ReadOnlyMemory<byte> memory) {
+      _memory = memory;
+      _position = 0;
+    }
+
+    public ReadOnlySpan<byte> RemainingSpan => _memory.Span.Slice(_position);
+    public int Remaining => _memory.Length - _position;
+
+    public bool TryReadBytes(int length, out ReadOnlyMemory<byte> value) {
+      if(_position + length > _memory.Length) {
+        value = default;
+        return false;
+      }
+
+      value = _memory.Slice(_position, length);
+      _position += length;
+      return true;
+    }
+
+    public bool TryReadByte(out byte value) {
+      if(_position >= _memory.Length) {
+        value = default;
+        return false;
+      }
+
+      value = _memory.Span[_position++];
+      return true;
+    }
+
+    public bool TryReadUInt16(out ushort value) {
+      if(_position + sizeof(ushort) > _memory.Length) {
+        value = default;
+        return false;
+      }
+
+      value = BinaryPrimitives.ReadUInt16BigEndian(_memory.Span.Slice(_position, sizeof(ushort)));
+      _position += sizeof(ushort);
+      return true;
+    }
+
+    public bool TryReadUInt32(out uint value) {
+      if(_position + sizeof(uint) > _memory.Length) {
+        value = default;
+        return false;
+      }
+
+      value = BinaryPrimitives.ReadUInt32BigEndian(_memory.Span.Slice(_position, sizeof(uint)));
+      _position += sizeof(uint);
+      return true;
+    }
+
+    public bool TryReadInt32(out int value) {
+      if(_position + sizeof(int) > _memory.Length) {
+        value = default;
+        return false;
+      }
+
+      value = BinaryPrimitives.ReadInt32BigEndian(_memory.Span.Slice(_position, sizeof(int)));
+      _position += sizeof(int);
+      return true;
+    }
+  }
+}

--- a/UTanksServer/Core/Protocol/BufferWriter.cs
+++ b/UTanksServer/Core/Protocol/BufferWriter.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Buffers;
+using System.Buffers.Binary;
+
+namespace UTanksServer.Core.Protocol {
+  public sealed class BufferWriter : IBufferWriter<byte>, IBufferWriter {
+    private readonly ArrayBufferWriter<byte> _writer = new ArrayBufferWriter<byte>();
+
+    public void Write(ReadOnlySpan<byte> source) {
+      Span<byte> destination = GetSpan(source.Length);
+      source.CopyTo(destination);
+      Advance(source.Length);
+    }
+
+    public void WriteByte(byte value) {
+      Span<byte> destination = GetSpan(1);
+      destination[0] = value;
+      Advance(1);
+    }
+
+    public void WriteUInt16(ushort value) {
+      Span<byte> destination = GetSpan(sizeof(ushort));
+      BinaryPrimitives.WriteUInt16BigEndian(destination, value);
+      Advance(sizeof(ushort));
+    }
+
+    public void WriteUInt32(uint value) {
+      Span<byte> destination = GetSpan(sizeof(uint));
+      BinaryPrimitives.WriteUInt32BigEndian(destination, value);
+      Advance(sizeof(uint));
+    }
+
+    public void WriteInt32(int value) {
+      Span<byte> destination = GetSpan(sizeof(int));
+      BinaryPrimitives.WriteInt32BigEndian(destination, value);
+      Advance(sizeof(int));
+    }
+
+    public Span<byte> GetSpan(int sizeHint = 0) => _writer.GetSpan(sizeHint);
+    public Memory<byte> GetMemory(int sizeHint = 0) => _writer.GetMemory(sizeHint);
+    public void Advance(int count) => _writer.Advance(count);
+    public ReadOnlyMemory<byte> WrittenMemory => _writer.WrittenMemory;
+    public int WrittenCount => _writer.WrittenCount;
+  }
+
+  public interface IBufferWriter {
+    void Write(ReadOnlySpan<byte> source);
+    void WriteByte(byte value);
+    void WriteUInt16(ushort value);
+    void WriteUInt32(uint value);
+    void WriteInt32(int value);
+  }
+}

--- a/UTanksServer/Core/Protocol/CommandCodecBootstrapper.cs
+++ b/UTanksServer/Core/Protocol/CommandCodecBootstrapper.cs
@@ -1,0 +1,23 @@
+using UTanksServer.Core.Protocol.Commands;
+
+namespace UTanksServer.Core.Protocol {
+  public static class CommandCodecBootstrapper {
+    private static bool _initialized;
+    private static readonly object Sync = new object();
+
+    public static void EnsureInitialized() {
+      if(_initialized) {
+        return;
+      }
+
+      lock(Sync) {
+        if(_initialized) {
+          return;
+        }
+
+        CommandCodecRegistry.Register(new HeartbeatCodec());
+        _initialized = true;
+      }
+    }
+  }
+}

--- a/UTanksServer/Core/Protocol/CommandCodecRegistry.cs
+++ b/UTanksServer/Core/Protocol/CommandCodecRegistry.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+
+using UTanksServer.Services.Servers.Game;
+
+namespace UTanksServer.Core.Protocol {
+  public interface ICommandCodec {
+    ushort TypeId { get; }
+    Type CommandType { get; }
+    void Encode(ref BufferWriter writer, ICommand command);
+    ICommand Decode(ref BufferReader reader, Player player);
+    int EstimateSize(ICommand command);
+  }
+
+  public static class CommandCodecRegistry {
+    private static readonly ConcurrentDictionary<Type, ICommandCodec> CodecsByType = new ConcurrentDictionary<Type, ICommandCodec>();
+    private static readonly ConcurrentDictionary<ushort, ICommandCodec> CodecsById = new ConcurrentDictionary<ushort, ICommandCodec>();
+
+    public static void Register(ICommandCodec codec) {
+      if(!CodecsByType.TryAdd(codec.CommandType, codec)) {
+        throw new InvalidOperationException($"Codec for type {codec.CommandType} already registered");
+      }
+
+      if(!CodecsById.TryAdd(codec.TypeId, codec)) {
+        throw new InvalidOperationException($"Codec id {codec.TypeId} already registered");
+      }
+    }
+
+    public static ICommandCodec GetByType(Type type) {
+      if(CodecsByType.TryGetValue(type, out ICommandCodec codec)) {
+        return codec;
+      }
+
+      throw new KeyNotFoundException($"Codec for {type} is not registered");
+    }
+
+    public static ICommandCodec GetById(ushort id) {
+      if(CodecsById.TryGetValue(id, out ICommandCodec codec)) {
+        return codec;
+      }
+
+      throw new KeyNotFoundException($"Codec with id {id} is not registered");
+    }
+  }
+}

--- a/UTanksServer/Core/Protocol/Commands/HeartbeatCommand.cs
+++ b/UTanksServer/Core/Protocol/Commands/HeartbeatCommand.cs
@@ -1,0 +1,34 @@
+using System.Threading.Tasks;
+
+using UTanksServer.Services.Servers.Game;
+using UTanksServer.Services.Servers.Game.Connection;
+
+namespace UTanksServer.Core.Protocol.Commands {
+  public sealed class HeartbeatCommand : ICommand, ICommandMetadataProvider {
+    public long ClientTime { get; init; }
+
+    public Task OnReceive(Player player) {
+      player.Connection?.QueueCommands(new HeartbeatCommand { ClientTime = ClientTime });
+      return Task.CompletedTask;
+    }
+
+    public CommandSendOptions GetSendOptions() => new CommandSendOptions(CommandPriority.Low, reliable: false, estimatedSize: 8);
+  }
+
+  public sealed class HeartbeatCodec : ICommandCodec {
+    public ushort TypeId => 1;
+    public System.Type CommandType => typeof(HeartbeatCommand);
+
+    public void Encode(ref BufferWriter writer, ICommand command) {
+      HeartbeatCommand heartbeat = (HeartbeatCommand) command;
+      writer.WriteUInt32((uint) heartbeat.ClientTime);
+    }
+
+    public ICommand Decode(ref BufferReader reader, Player player) {
+      reader.TryReadUInt32(out uint clientTime);
+      return new HeartbeatCommand { ClientTime = clientTime };
+    }
+
+    public int EstimateSize(ICommand command) => sizeof(uint);
+  }
+}

--- a/UTanksServer/Core/Protocol/DataDecoder.cs
+++ b/UTanksServer/Core/Protocol/DataDecoder.cs
@@ -1,330 +1,67 @@
-//using System;
-//using System.Collections;
-//using System.Collections.Generic;
-//using System.IO;
-//using System.Linq;
-//using System.Numerics;
-//using System.Reflection;
-//using System.Runtime.Serialization;
-//using System.Text;
-//using UTanksServer.Core.Commands;
-//using UTanksServer.ECS.ECSCore;
-//using UTanksServer.ECS.Components.Battle.Tank;
-//using UTanksServer.ECS.Events.Battle;
-//using UTanksServer.ECS.Events.Battle.Movement;
-//using UTanksServer.ECS.Types;
-//using UTanksServer.Library;
-//using static UTanksServer.Core.Commands.PacketTools;
-
-//namespace UTanksServer.Core.Protocol
-//{
-//    class DataDecoder
-//    {
-//        public bool IsCommandIgnored { get; private set; }
-
-//        private readonly BinaryReader reader;
-//        private readonly OptionalMap map;
-
-//        private readonly Dictionary<Type, Func<object>> decodeMethods;
-
-//        private DataDecoder()
-//        {
-//            decodeMethods = new Dictionary<Type, Func<object>>
-//            {
-//                { typeof(string), DecodeString },
-//                { typeof(Vector3), DecodeVector3 },
-//                { typeof(MoveCommand), DecodeMoveCommand },
-//                { typeof(Movement), DecodeMovement },
-//                { typeof(Type), DecodeType },
-//                { typeof(DateTime), DecodeDateTime }
-//            };
-//        }
-
-//        public DataDecoder(BinaryReader reader) : this()
-//        {
-//            this.reader = reader;
-//        }
-
-//        private DataDecoder(BinaryReader reader, OptionalMap map) : this()
-//        {
-//            this.reader = reader;
-//            this.map = map;
-//        }
-
-//        private object DecodePrimitive(Type objType)
-//        {
-//            return reader.GetType()
-//                         .GetMethods()
-//                         .Single(method => method.Name == "Read" + objType.Name)
-//                         .Invoke(reader, null);
-//        }
-
-//        private object DecodeString()
-//        {
-//            return Encoding.UTF8.GetString(reader.ReadBytes(DecodeLength(reader)));
-//        }
-
-//        private int DecodeLength(BinaryReader buf)
-//        {
-//            byte num1 = buf.ReadByte();
-//            if ((num1 & 128) == 0) return num1;
-            
-//            byte num2 = buf.ReadByte();
-//            if ((num1 & 64) == 0) return ((num1 & 63) << 8) + (num2 & byte.MaxValue);
-            
-//            byte num3 = buf.ReadByte();
-//            return ((num1 & 63) << 16) + ((num2 & byte.MaxValue) << 8) + (num3 & byte.MaxValue);
-//        }
-
-//        private object DecodeCollection(Type objType, Player player)
-//        {
-//            int count = DecodeLength(reader);
-
-//            if (objType.IsArray)
-//            {
-//                Type elementType = objType.GetElementType();
-//                Array array = Array.CreateInstance(elementType, count);
-
-//                for (int i = 0; i < count; i++)
-//                {
-//                    object item = SelectDecode(elementType, player);
-
-//                    if (elementType == typeof(ECSEntity) && item == null)
-//                    {
-//                        IsCommandIgnored = true;
-//                        continue;
-//                    }
-
-//                    array.SetValue(item, i);
-//                }
-
-//                return array;
-//            }
-
-//            object obj = Activator.CreateInstance(objType);
-//            Type collectionInnerType = objType.GetGenericArguments()[0];
-
-//            for (int i = 0; i < count; i++)
-//            {
-//                object item = SelectDecode(collectionInnerType, player);
-//                if (collectionInnerType == typeof(ECSEntity) && item == null) continue;
-
-//                objType.GetMethod("Add", new Type[] { collectionInnerType })
-//                    .Invoke(obj, new object[] { item });
-//            }
-
-//            return obj;
-//        }
-
-//        private object DecodeEntity(Player player)
-//        {
-//            Int64 EntityId = reader.ReadInt64();
-
-//            return player.FindEntityById(EntityId);
-//        }
-
-//        private object DecodeDateTime()
-//        {
-//            return new DateTime(DateTime.UnixEpoch.Ticks + reader.ReadInt64() * 10000);
-//        }
-
-//        private object DecodeVector3()
-//        {
-//            return new Vector3(reader.ReadSingle(), reader.ReadSingle(), reader.ReadSingle());
-//        }
-
-//        private object DecodeCommand(Player player)
-//        {
-//            Type objType = FindCommandType(reader.ReadByte());
-
-//            return DecodeObject(objType, player);
-//        }
-
-//        private object DecodeMoveCommand()
-//        {
-//            const int WEAPON_ROTATION_SIZE = 2;
-//            const int WEAPON_ROTATION_COMPONENT_BITSIZE = WEAPON_ROTATION_SIZE * 8;
-//            const float WEAPON_ROTATION_FACTOR = 360f / (1 << WEAPON_ROTATION_COMPONENT_BITSIZE);
-
-//            byte[] bufferEmpty = Array.Empty<byte>();
-//            byte[] bufferForWeaponRotation = new byte[WEAPON_ROTATION_SIZE];
-
-//            BitArray bitsEmpty = new(bufferEmpty);
-//            BitArray bitsForWeaponRotation = new(bufferForWeaponRotation);
-
-//            bool hasMovement = map.Read();
-//            bool hasWeaponRotation = map.Read();
-//            bool isDiscrete = map.Read();
-
-//            MoveCommand moveCommand = default;
-//            if (isDiscrete)
-//            {
-//                DiscreteTankControl discreteTankControl = new() { Control = reader.ReadByte() };
-//                moveCommand.TankControlHorizontal = discreteTankControl.TurnAxis;
-//                moveCommand.TankControlVertical = discreteTankControl.MoveAxis;
-//                moveCommand.WeaponRotationControl = discreteTankControl.WeaponControl;
-//            }
-//            else
-//            {
-//                moveCommand.TankControlVertical = reader.ReadSingle();
-//                moveCommand.TankControlHorizontal = reader.ReadSingle();
-//                moveCommand.WeaponRotationControl = reader.ReadSingle();
-//            }
-
-//            if (hasMovement)
-//                moveCommand.Movement = MovementCodec.Decode(reader);
-
-//            byte[] buffer = hasWeaponRotation ? bufferForWeaponRotation : bufferEmpty;
-//            BitArray bits = hasWeaponRotation ? bitsForWeaponRotation : bitsEmpty;
-//            int weaponRotationBitLength = 0;
-
-//            reader.Read(buffer, 0, buffer.Length);
-//            MovementCodec.CopyBits(buffer, bits);
-
-//            if (hasWeaponRotation)
-//                moveCommand.WeaponRotation = new float?(MovementCodec.ReadFloat(bits, ref weaponRotationBitLength, WEAPON_ROTATION_COMPONENT_BITSIZE, WEAPON_ROTATION_FACTOR));
-
-//            if (weaponRotationBitLength != bits.Length)
-//                throw new Exception("Move command unpack mismatch");
-
-//            moveCommand.ClientTime = reader.ReadInt32();
-
-//            return moveCommand;
-//        }
-
-//        private object DecodeMovement()
-//        {
-//            return MovementCodec.Decode(reader);
-//        }
-
-//        private object DecodeType()
-//        {
-//            return SerialVersionUIDTools.FindType(reader.ReadInt64());
-//        }
-
-//        private object SelectDecode(Type objType, Player player)
-//        {
-//            if (objType.IsPrimitive || objType == typeof(decimal))
-//            {
-//                return DecodePrimitive(objType);
-//            }
-
-//            if (decodeMethods.TryGetValue(objType, out Func<object> method))
-//            {
-//                return method();
-//            }
-
-//            if (objType.IsEnum)
-//            {
-//                return Enum.ToObject(objType, reader.ReadByte());
-//            }
-
-//            if (objType == typeof(Entity))
-//            {
-//                return DecodeEntity(player);
-//            }
-
-//            // if (typeof(DateTimeOffset).IsAssignableFrom(objType))
-//            // {
-//            //     long time = reader.ReadInt64();
-//            //     return DateTimeOffset.FromUnixTimeMilliseconds(time + player.Connection.DiffToClient);
-//            // }
-
-//            if (typeof(IDictionary).IsAssignableFrom(objType))
-//            {
-//                throw new NotImplementedException();
-//            }
-            
-//            if (objType.IsArray || (objType.IsGenericType && typeof(ICollection<>).MakeGenericType(objType.GetGenericArguments()[0]).IsAssignableFrom(objType)))
-//            {
-//                return DecodeCollection(objType, player);
-//            }
-
-//            if (typeof(ICommand).IsAssignableFrom(objType))
-//            {
-//                return DecodeCommand(player);
-//            }
-
-//            if (objType.IsAbstract || objType.IsInterface)
-//            {
-//                objType = (Type)DecodeType();
-//                return UnpackData(player, objType);
-//            }
-
-//            return DecodeObject(objType, player);
-//        }
-
-//        private object DecodeObject(Type objType, Player player)
-//        {
-//            object obj = FormatterServices.GetUninitializedObject(objType);
-
-//            foreach (PropertyInfo info in GetProtocolProperties(objType))
-//            {
-//                if (Attribute.IsDefined(info, typeof(OptionalMappedAttribute)))
-//                    if (map.Read()) continue;
-
-//                object decoded = SelectDecode(info.PropertyType, player);
-//                if (info.PropertyType == typeof(Entity) && decoded == null)
-//                {
-//                    IsCommandIgnored = true;
-//                    continue;
-//                }
-
-//                info.SetValue(obj, decoded);
-//            }
-
-//            return obj;
-//        }
-
-//        private object UnpackData(Player player, Type objType = null)
-//        {
-//            Int32 mapLength, length;
-
-//            // Magic.
-//            byte[] readMagic = reader.ReadBytes(2);
-//            if (readMagic.Length < 2)
-//                throw new IOException("Unexpected client error.");
-//            else if (!readMagic.SequenceEqual(Magic))
-//                throw new IOException($"Invalid packet magic: {BitConverter.ToString(readMagic)}");
-
-//            // Length values.
-//            mapLength = reader.ReadInt32();
-//            length = reader.ReadInt32();
-
-//            // OptionalMap and packet contents.
-//            OptionalMap map = new OptionalMap(reader.ReadBytes((int)Math.Ceiling(mapLength / 8.0)), mapLength);
-
-//            using (MemoryStream stream = new MemoryStream(reader.ReadBytes(length)))
-//            {
-//                BinaryReader buffer = new BigEndianBinaryReader(stream);
-//                DataDecoder decoder = new DataDecoder(buffer, map);
-
-//                if (objType != null)
-//                {
-//                    object obj = decoder.DecodeObject(objType, player);
-//                    IsCommandIgnored |= decoder.IsCommandIgnored;
-//                    return obj;
-//                }
-
-//                // Deserialize objects.
-//                List<ICommand> commands = new List<ICommand>();
-
-//                while (buffer.BaseStream.Position != length)
-//                {
-//                    ICommand command = decoder.SelectDecode(typeof(ICommand), player) as ICommand;
-//                    if (decoder.IsCommandIgnored)
-//                    {
-//                        decoder.IsCommandIgnored = false;
-//                        continue;
-//                    }
-
-//                    commands.Add(command);
-//                }
-
-//                return commands;
-//            }
-//        }
-
-//        public List<ICommand> DecodeCommands(Player player) => UnpackData(player) as List<ICommand>;
-//    }
-//}
+using System;
+using System.Collections.Generic;
+
+using UTanksServer.Services.Servers.Game;
+using UTanksServer.Services.Servers.Game.Connection;
+
+namespace UTanksServer.Core.Protocol {
+  public sealed class DataDecoder {
+    public DecodedPacket Decode(ReadOnlyMemory<byte> packet, Player player) {
+      BufferReader reader = new BufferReader(packet);
+      if(!reader.TryReadInt32(out int length)) {
+        throw new InvalidOperationException("Packet truncated");
+      }
+
+      if(length != reader.Remaining) {
+        throw new InvalidOperationException("Invalid packet length");
+      }
+
+      if(!reader.TryReadUInt32(out uint sequence)) {
+        throw new InvalidOperationException("Missing sequence");
+      }
+
+      if(!reader.TryReadUInt32(out uint ack)) {
+        throw new InvalidOperationException("Missing ack");
+      }
+
+      if(!reader.TryReadUInt32(out uint ackMask)) {
+        throw new InvalidOperationException("Missing ack mask");
+      }
+
+      if(!reader.TryReadUInt16(out ushort commandCount)) {
+        throw new InvalidOperationException("Missing command count");
+      }
+
+      List<ReceivedCommand> commands = new List<ReceivedCommand>(commandCount);
+      for(int i = 0; i < commandCount; i++) {
+        if(!reader.TryReadUInt16(out ushort typeId)) {
+          throw new InvalidOperationException("Missing command type id");
+        }
+
+        if(!reader.TryReadByte(out byte flags)) {
+          throw new InvalidOperationException("Missing flags");
+        }
+
+        if(!reader.TryReadUInt16(out ushort payloadLength)) {
+          throw new InvalidOperationException("Missing payload length");
+        }
+
+        if(!reader.TryReadBytes(payloadLength, out ReadOnlyMemory<byte> payload)) {
+          throw new InvalidOperationException("Truncated payload");
+        }
+
+        BufferReader payloadReader = new BufferReader(payload);
+        ICommandCodec codec = CommandCodecRegistry.GetById(typeId);
+        ICommand command = codec.Decode(ref payloadReader, player);
+        CommandPriority priority = (CommandPriority) (flags & 0b111);
+        bool reliable = (flags & 0b1000) != 0;
+        commands.Add(new ReceivedCommand(command, priority, reliable));
+      }
+
+      return new DecodedPacket(sequence, ack, ackMask, commands);
+    }
+  }
+
+  public readonly record struct ReceivedCommand(ICommand Command, CommandPriority Priority, bool Reliable);
+  public readonly record struct DecodedPacket(uint Sequence, uint Ack, uint AckMask, IReadOnlyList<ReceivedCommand> Commands);
+}

--- a/UTanksServer/Core/Protocol/DataEncoder.cs
+++ b/UTanksServer/Core/Protocol/DataEncoder.cs
@@ -1,293 +1,75 @@
-//using System;
-//using System.Collections;
-//using System.Collections.Generic;
-//using System.IO;
-//using System.Numerics;
-//using System.Reflection;
-//using System.Text;
-//using UTanksServer.Core.Commands;
-//using UTanksServer.ECSSystem.Base;
-//using UTanksServer.ECSSystem.Components.Battle.Tank;
-//using UTanksServer.ECSSystem.Events.Battle;
-//using UTanksServer.ECSSystem.Events.Battle.Movement;
-//using UTanksServer.ECSSystem.Types;
-//using UTanksServer.Library;
-//using static UTanksServer.Core.Commands.PacketTools;
+using System;
+using System.Buffers;
+using System.Buffers.Binary;
+using System.Collections.Generic;
 
-//namespace UTanksServer.Core.Protocol
-//{
-//    class DataEncoder
-//    {
-//        private static byte[] bufferEmpty = Array.Empty<byte>();
-//        private static BitArray bitsEmpty = new BitArray(bufferEmpty);
-//        private const int WEAPON_ROTATION_SIZE = 2;
-//        private static byte[] bufferForWeaponRotation = new byte[WEAPON_ROTATION_SIZE];
-//        private static BitArray bitsForWeaponRotation = new BitArray(bufferForWeaponRotation);
-//        private const int WEAPON_ROTATION_COMPONENT_BITSIZE = WEAPON_ROTATION_SIZE * 8;
-//        private const float WEAPON_ROTATION_FACTOR = 360f / (1 << WEAPON_ROTATION_COMPONENT_BITSIZE);
+using UTanksServer.Services.Servers.Game;
+using UTanksServer.Services.Servers.Game.Connection;
 
-//        private readonly BinaryWriter writer;
-//        private readonly OptionalMap map;
+namespace UTanksServer.Core.Protocol {
+  public sealed class DataEncoder {
+    private readonly ArrayPool<byte> _pool;
 
-//        private DataEncoder() { }
+    public DataEncoder(ArrayPool<byte>? pool = null) {
+      _pool = pool ?? ArrayPool<byte>.Shared;
+    }
 
-//        public DataEncoder(BinaryWriter writer)
-//        {
-//            this.writer = writer;
-//        }
+    public PooledPacket Encode(IReadOnlyList<QueuedCommand> commands, uint sequence, uint ack, uint ackMask) {
+      BufferWriter writer = new BufferWriter();
+      writer.WriteInt32(0); // Placeholder for total length
+      writer.WriteUInt32(sequence);
+      writer.WriteUInt32(ack);
+      writer.WriteUInt32(ackMask);
+      writer.WriteUInt16((ushort) commands.Count);
 
-//        private DataEncoder(BinaryWriter writer, OptionalMap map)
-//        {
-//            this.writer = writer;
-//            this.map = map;
-//        }
+      for(int i = 0; i < commands.Count; i++) {
+        QueuedCommand queued = commands[i];
+        ICommand command = queued.Command;
+        ICommandCodec codec = CommandCodecRegistry.GetByType(command.GetType());
 
-//        private void EncodePrimitive(object obj)
-//        {
-//            writer.GetType()
-//                  .GetMethod("Write", new Type[] { obj.GetType() })
-//                  .Invoke(writer, new object[] { obj });
-//        }
+        BufferWriter payloadWriter = new BufferWriter();
+        codec.Encode(ref payloadWriter, command);
+        int payloadLength = payloadWriter.WrittenCount;
 
-//        private void EncodeLength(int length)
-//        {
-//            if (length < 128)
-//            {
-//                writer.Write((byte)(length & 127));
-//            }
-//            else if (length < 16384)
-//            {
-//                long num = (length & 16383) + 32768;
-//                writer.Write((byte)((num & 65280L) >> 8));
-//                writer.Write((byte)(num & 255L));
-//            }
-//            else
-//            {
-//                if (length >= 4194304)
-//                {
-//                    throw new IndexOutOfRangeException("length=" + length);
-//                }
-//                long num2 = (length & 4194303) + 12582912;
-//                writer.Write((byte)((num2 & 16711680L) >> 16));
-//                writer.Write((byte)((num2 & 65280L) >> 8));
-//                writer.Write((byte)(num2 & 255L));
-//            }
-//        }
+        byte flags = EncodeFlags(queued.Options);
+        writer.WriteUInt16(codec.TypeId);
+        writer.WriteByte(flags);
+        writer.WriteUInt16((ushort) payloadLength);
+        writer.Write(payloadWriter.WrittenMemory.Span);
+      }
 
-//        private void EncodeString(string str)
-//        {
-//            byte[] data = Encoding.UTF8.GetBytes(str);
-//            EncodeLength(data.Length);
-//            writer.Write(data);
-//        }
+      int packetLength = writer.WrittenCount - sizeof(int);
+      Span<byte> lengthSpan = writer.WrittenMemory.Span.Slice(0, sizeof(int));
+      BinaryPrimitives.WriteInt32BigEndian(lengthSpan, packetLength);
 
-//        private void EncodeCollection(ICollection collection)
-//        {
-//            writer.Write((byte)collection.Count);
+      byte[] rented = _pool.Rent(writer.WrittenCount);
+      writer.WrittenMemory.Span.CopyTo(rented);
+      return new PooledPacket(_pool, rented, writer.WrittenCount);
+    }
 
-//            foreach (object el in collection)
-//            {
-//                SelectEncode(el);
-//            }
-//        }
+    private static byte EncodeFlags(CommandSendOptions options) {
+      int priority = (int) options.Priority;
+      byte flags = (byte) (priority & 0b111);
+      if(options.Reliable) {
+        flags |= 0b1000;
+      }
+      return flags;
+    }
+  }
 
-//        private void EncodeCommand(ICommand command)
-//        {
-//            Type type = command.GetType();
+  public readonly struct PooledPacket : IDisposable {
+    private readonly ArrayPool<byte> _pool;
+    public byte[] Buffer { get; }
+    public int Length { get; }
 
-//            writer.Write(GetCommandCode(type));
-//        }
+    public PooledPacket(ArrayPool<byte> pool, byte[] buffer, int length) {
+      _pool = pool;
+      Buffer = buffer;
+      Length = length;
+    }
 
-//        private void EncodeEntity(Entity entity)
-//        {
-//            writer.Write(entity.EntityId);
-//        }
-
-//        private void EncodeEnum(Enum @enum)
-//        {
-//            writer.Write(Convert.ToByte(@enum));
-//        }
-
-//        [System.Diagnostics.CodeAnalysis.SuppressMessage("CodeQuality", "IDE0051:Удалите неиспользуемые закрытые члены", Justification = "<Ожидание>")]
-//        private void EncodeHashSet<T>(HashSet<T> set)
-//        {
-//            writer.Write((byte)set.Count);
-
-//            foreach (object el in set)
-//            {
-//                SelectEncode(el);
-//            }
-//        }
-
-//        private void EncodeDateTime(DateTime time)
-//        {
-//            writer.Write((time.ToUniversalTime() - DateTime.UnixEpoch).Ticks / 10000);
-//        }
-
-//        private void EncodeVector3(Vector3 vector3)
-//        {
-//            writer.Write(vector3.X);
-//            writer.Write(vector3.Y);
-//            writer.Write(vector3.Z);
-//        }
-
-//        private void EncodeMoveCommand(MoveCommand moveCommand)
-//        {
-//            bool hasMovement = moveCommand.Movement != null;
-//            bool hasWeaponRotation = moveCommand.WeaponRotation != null;
-//            bool isDiscrete = moveCommand.IsDiscrete();
-
-//            map.Add(hasMovement);
-//            map.Add(hasWeaponRotation);
-//            map.Add(isDiscrete);
-
-//            if (isDiscrete)
-//            {
-//                writer.Write(new DiscreteTankControl()
-//                {
-//                    MoveAxis = (int)moveCommand.TankControlVertical,
-//                    TurnAxis = (int)moveCommand.TankControlHorizontal,
-//                    WeaponControl = (int)moveCommand.WeaponRotationControl,
-//                }.Control);
-//            }
-//            else
-//            {
-//                writer.Write(moveCommand.TankControlVertical);
-//                writer.Write(moveCommand.TankControlHorizontal);
-//                writer.Write(moveCommand.WeaponRotationControl);
-//            }
-
-//            if (hasMovement)
-//                MovementCodec.Encode(writer, moveCommand.Movement.Value);
-
-//            if (hasWeaponRotation)
-//            {
-//                byte[] buffer = bufferForWeaponRotation;
-//                BitArray bits = bitsForWeaponRotation;
-//                int position = 0;
-
-//                MovementCodec.WriteFloat(bits, ref position, moveCommand.WeaponRotation.Value, WEAPON_ROTATION_COMPONENT_BITSIZE, WEAPON_ROTATION_FACTOR);
-//                bits.CopyTo(buffer, 0);
-//                writer.Write(buffer);
-
-//                if (position != bits.Length)
-//                    throw new Exception("Move command pack mismatch");
-//            }
-
-//            writer.Write(moveCommand.ClientTime);
-//        }
-
-//        private void EncodeType(Type type)
-//        {
-//            writer.Write(SerialVersionUIDTools.GetId(type));
-//        }
-        
-//        private void SelectEncode(object obj)
-//        {
-//            Type objType = obj.GetType();
-
-//            if (objType.IsPrimitive || objType == typeof(decimal))
-//            {
-//                EncodePrimitive(obj);
-//                return;
-//            }
-
-//            switch (obj)
-//            {
-//                case string str:
-//                    EncodeString(str);
-//                    return;
-//                case Entity entity:
-//                    EncodeEntity(entity);
-//                    return;
-//                case IEntityTemplate _:
-//                    EncodeType(objType);
-//                    return;
-//                case ICollection collection:
-//                    EncodeCollection(collection);
-//                    return;
-//                case ICommand command:
-//                    EncodeCommand(command);
-//                    break;
-//                case Enum @enum:
-//                    EncodeEnum(@enum);
-//                    return;
-//                case DateTime date:
-//                    EncodeDateTime(date);
-//                    return;
-//                case Vector3 vector3:
-//                    EncodeVector3(vector3);
-//                    return;
-//                case Movement movement:
-//                    MovementCodec.Encode(writer, movement);
-//                    return;
-//                case MoveCommand moveCommand:
-//                    EncodeMoveCommand(moveCommand);
-//                    return;
-//                case Type type:
-//                    EncodeType(type);
-//                    return;
-//            }
-
-//            if (objType.IsGenericType && objType.GetGenericTypeDefinition() == typeof(HashSet<>))
-//            {
-//                typeof(DataEncoder).GetMethod("EncodeHashSet", BindingFlags.NonPublic | BindingFlags.Instance)
-//                                   .MakeGenericMethod(objType.GetGenericArguments()[0])
-//                                   .Invoke(this, new object[] { obj });
-//                return;
-//            }
-
-//            if (Attribute.IsDefined(objType, typeof(SerialVersionUIDAttribute)))
-//            {
-//                EncodeType(objType);
-//            }
-
-//            EncodeObject(obj);
-//        }
-
-//        private void EncodeObject(object obj)
-//        {
-//            foreach (PropertyInfo info in GetProtocolProperties(obj.GetType()))
-//            {
-//                object value = info.GetValue(obj);
-
-//                if (Attribute.IsDefined(info, typeof(OptionalMappedAttribute)))
-//                {
-//                    map.Add(value == null);
-//                    if (value == null) continue;
-//                }
-//                else if (value == null)
-//                    throw new ArgumentNullException(info.Name, "From " + info.ReflectedType.FullName);
-
-//                SelectEncode(value);
-//            }
-//        }
-
-//        public void EncodeCommands(IEnumerable<ICommand> commands)
-//        {
-//            using (MemoryStream memoryStream = new MemoryStream())
-//            {
-//                BinaryWriter writtenCommands = new BigEndianBinaryWriter(memoryStream);
-
-//                OptionalMap map = new OptionalMap();
-//                DataEncoder encoder = new DataEncoder(writtenCommands, map);
-
-//                foreach (ICommand command in commands)
-//                {
-//                    encoder.SelectEncode(command);
-//                }
-
-//                map.Reset();
-
-//                writer.Write(Magic);
-//                writer.Write(map.Length);
-//                writer.Write((UInt32)writtenCommands.BaseStream.Length);
-
-//                writer.Write(map.GetBytes());
-
-//                writtenCommands.BaseStream.Position = 0;
-//                writtenCommands.BaseStream.CopyTo(writer.BaseStream);
-//            }
-//        }
-//    }
-//}
+    public void Dispose() {
+      _pool.Return(Buffer, clearArray: false);
+    }
+  }
+}

--- a/UTanksServer/Diagnostics/PerfCounters.cs
+++ b/UTanksServer/Diagnostics/PerfCounters.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Collections.Concurrent;
+using System.Diagnostics;
+
+namespace UTanksServer.Diagnostics {
+  public static class PerfCounters {
+    private static readonly ConcurrentDictionary<string, Counter> Counters = new ConcurrentDictionary<string, Counter>();
+
+    public static IDisposable TrackDuration(string name) {
+      Counter counter = Counters.GetOrAdd(name, _ => new Counter());
+      return counter.Track();
+    }
+
+    public static void Increment(string name, double value = 1.0) {
+      Counter counter = Counters.GetOrAdd(name, _ => new Counter());
+      counter.Add(value);
+    }
+
+    private sealed class Counter {
+      private double _value;
+      private readonly object _sync = new object();
+
+      public IDisposable Track() {
+        Stopwatch sw = Stopwatch.StartNew();
+        return new Scope(sw, this);
+      }
+
+      public void Add(double value) {
+        lock(_sync) {
+          _value += value;
+        }
+      }
+
+      private void Observe(TimeSpan duration) {
+        lock(_sync) {
+          _value = duration.TotalMilliseconds;
+        }
+      }
+
+      private sealed class Scope : IDisposable {
+        private readonly Stopwatch _stopwatch;
+        private readonly Counter _counter;
+        private bool _disposed;
+
+        public Scope(Stopwatch stopwatch, Counter counter) {
+          _stopwatch = stopwatch;
+          _counter = counter;
+        }
+
+        public void Dispose() {
+          if(_disposed) {
+            return;
+          }
+
+          _disposed = true;
+          _stopwatch.Stop();
+          _counter.Observe(_stopwatch.Elapsed);
+        }
+      }
+    }
+  }
+}

--- a/UTanksServer/Services/Servers/Game/Connection/CommandMetadataExtensions.cs
+++ b/UTanksServer/Services/Servers/Game/Connection/CommandMetadataExtensions.cs
@@ -1,0 +1,11 @@
+namespace UTanksServer.Services.Servers.Game.Connection {
+  public static class CommandMetadataExtensions {
+    public static CommandSendOptions GetSendOptions(this ICommand command) {
+      if(command is ICommandMetadataProvider provider) {
+        return provider.GetSendOptions();
+      }
+
+      return CommandSendOptions.Default;
+    }
+  }
+}

--- a/UTanksServer/Services/Servers/Game/Connection/CommandPriority.cs
+++ b/UTanksServer/Services/Servers/Game/Connection/CommandPriority.cs
@@ -1,0 +1,9 @@
+namespace UTanksServer.Services.Servers.Game.Connection {
+  public enum CommandPriority {
+    Critical = 0,
+    High = 1,
+    Normal = 2,
+    Low = 3,
+    Background = 4
+  }
+}

--- a/UTanksServer/Services/Servers/Game/Connection/CommandSendOptions.cs
+++ b/UTanksServer/Services/Servers/Game/Connection/CommandSendOptions.cs
@@ -1,0 +1,26 @@
+using System;
+
+namespace UTanksServer.Services.Servers.Game.Connection {
+  public readonly struct CommandSendOptions {
+    public static readonly CommandSendOptions Default = new CommandSendOptions(CommandPriority.Normal, reliable: false, estimatedSize: 128);
+
+    public CommandSendOptions(CommandPriority priority, bool reliable, int estimatedSize) {
+      Priority = priority;
+      Reliable = reliable;
+      EstimatedSize = Math.Max(0, estimatedSize);
+    }
+
+    public CommandPriority Priority { get; }
+    public bool Reliable { get; }
+    public int EstimatedSize { get; }
+
+    public CommandSendOptions WithEstimatedSize(int size) => new CommandSendOptions(Priority, Reliable, size);
+
+    public CommandSendOptions Promote(CommandPriority priority) {
+      CommandPriority effective = priority < Priority ? priority : Priority;
+      return new CommandSendOptions(effective, Reliable, EstimatedSize);
+    }
+
+    public CommandSendOptions RequireReliability() => new CommandSendOptions(Priority, reliable: true, EstimatedSize);
+  }
+}

--- a/UTanksServer/Services/Servers/Game/Connection/ICommandMetadataProvider.cs
+++ b/UTanksServer/Services/Servers/Game/Connection/ICommandMetadataProvider.cs
@@ -1,0 +1,5 @@
+namespace UTanksServer.Services.Servers.Game.Connection {
+  public interface ICommandMetadataProvider {
+    CommandSendOptions GetSendOptions();
+  }
+}

--- a/UTanksServer/Services/Servers/Game/Connection/IPlayerConnection.cs
+++ b/UTanksServer/Services/Servers/Game/Connection/IPlayerConnection.cs
@@ -1,16 +1,16 @@
+using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace UTanksServer.Services.Servers.Game.Connection {
-  public interface IPlayerConnection {
-    public bool IsConnected { get; }
+  public interface IPlayerConnection : IAsyncDisposable {
+    Player Player { get; }
+    bool IsConnected { get; }
 
-    public AsyncQueue<ICommand> CommandQueue { get; }
+    ValueTask InitializeAsync(Player player, GameServer server, CancellationToken token);
+    Task RunAsync(CancellationToken token);
 
-    public Task Init();
-    public Task ReceivePackets();
-    public Task SendPackets();
-
-    public void QueueCommands(params ICommand[] commands);
-    public Task SendCommands(params ICommand[] commands);
+    bool QueueCommands(params ICommand[] commands);
+    void Disconnect();
   }
 }

--- a/UTanksServer/Services/Servers/Game/Connection/PlayerSocketConnection.cs
+++ b/UTanksServer/Services/Servers/Game/Connection/PlayerSocketConnection.cs
@@ -1,191 +1,463 @@
-//using System;
-//using System.IO;
-//using System.Net;
-//using System.Linq;
-//using System.Threading;
-//using System.Net.Sockets;
-//using System.Threading.Tasks;
-//using System.Collections.Generic;
-//using System.Text;
-//using Serilog;
-//using UTanksServer.Extensions;
+using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+using System.IO.Pipelines;
 
-//namespace UTanksServer.Services.Servers.Game.Connection
-//{
-//    public class PlayerSocketConnection : IPlayerConnection
-//    {
-//        private static readonly ILogger Logger = Log.Logger.ForType<PlayerSocketConnection>();
+using Serilog;
 
-//        public Player Player { get; set; }
+using UTanksServer.Core.Logging;
+using UTanksServer.Core.Protocol;
+using UTanksServer.Diagnostics;
+using UTanksServer.Services.Servers.Game.Security;
 
-//        public bool IsConnected { get; protected set; }
+namespace UTanksServer.Services.Servers.Game.Connection {
+  public sealed class PlayerSocketConnection : IPlayerConnection {
+    private static readonly ILogger Logger = Log.Logger.ForContext<PlayerSocketConnection>();
 
-//        public Socket Socket { get; }
-//        public IPEndPoint Endpoint => (IPEndPoint)Socket.RemoteEndPoint;
+    private readonly Socket _socket;
+    private readonly GameServerConfig _config;
+    private readonly SendQuotaManager _quotaManager;
+    private readonly AntiFloodController _antiFlood;
+    private readonly ArrayPool<byte> _pool = ArrayPool<byte>.Shared;
 
-//        public AsyncQueue<ICommand> CommandQueue { get; }
+    private readonly Queue<QueuedCommand>[] _queues;
+    private readonly SemaphoreSlim _sendSignal = new SemaphoreSlim(0);
+    private readonly object _queueLock = new object();
+    private int _queuedBytes;
 
-//        private readonly CancellationTokenSource _cancellationTokenSource;
+    private readonly Pipe _pipe = new Pipe();
+    private readonly CancellationTokenSource _cts = new CancellationTokenSource();
 
-//        public PlayerSocketConnection(Socket socket)
-//        {
-//            Socket = socket;
-//            CommandQueue = new AsyncQueue<ICommand>();
+    private readonly Dictionary<uint, PendingReliable> _pendingReliables = new Dictionary<uint, PendingReliable>();
 
-//            _cancellationTokenSource = new CancellationTokenSource();
-//        }
+    private uint _nextOutboundSequence = 1;
+    private uint _lastReceivedSequence;
+    private uint _receivedMask;
+    private readonly object _ackLock = new object();
 
-//        public async Task Init()
-//        {
-//            Player.ClientSession = ClientSessionTemplate.CreateEntity(
-//              "AI5q8XLJibe9vwx50OoS4A6nHai3oNd6U3ct96535B3azEoHfWKXQYOV6CbJfXUOBAoUvDzVbJGiOXPED9k0jAM=:AQAB"
-//            );
+    private Task? _sendTask;
+    private Task? _receiveTask;
 
-//            await SendCommands(new InitTimeCommand());
-//            Player.ShareEntities(Player.ClientSession);
-//        }
+    public Player Player { get; private set; } = null!;
+    public bool IsConnected => !_cts.IsCancellationRequested && _socket.Connected;
 
-//        public async Task ReceivePackets()
-//        {
-//            byte[] buffer = GC.AllocateArray<byte>(4096, true);
-//            Memory<byte> memory = buffer.AsMemory();
+    public PlayerSocketConnection(Socket socket, GameServerConfig config, SendQuotaManager quotaManager, AntiFloodController antiFlood) {
+      _socket = socket;
+      _config = config;
+      _quotaManager = quotaManager;
+      _antiFlood = antiFlood;
 
-//            while (true)
-//            {
-//                try
-//                {
-//                    int bytesReceived = await Socket.ReceiveAsync(memory, SocketFlags.None, _cancellationTokenSource.Token);
-//                    if (bytesReceived == 0)
-//                    {
-//                        Logger.WithPlayer(Player).Verbose(
-//                          "Lost connection"
-//                        );
-//                        _cancellationTokenSource.Cancel();
-//                        break;
-//                    }
+      _queues = Enumerable.Range(0, Enum.GetValues(typeof(CommandPriority)).Length)
+        .Select(_ => new Queue<QueuedCommand>())
+        .ToArray();
+    }
 
-//                    // Logger.WithPlayer(Player).Verbose(
-//                    //   "Received: {@Data}",
-//                    //   memory[..bytesReceived].ToArray()
-//                    // );
+    public ValueTask InitializeAsync(Player player, GameServer server, CancellationToken token) {
+      Player = player;
+      CommandCodecBootstrapper.EnsureInitialized();
+      return ValueTask.CompletedTask;
+    }
 
-//                    await using MemoryStream stream = new MemoryStream(buffer);
-//                    using BinaryReader reader = new BigEndianBinaryReader(stream);
-//                    DataDecoder decoder = new DataDecoder(reader);
+    public async Task RunAsync(CancellationToken token) {
+      using CancellationTokenSource linkedCts = CancellationTokenSource.CreateLinkedTokenSource(token, _cts.Token);
+      CancellationToken linkedToken = linkedCts.Token;
 
-//                    List<ICommand> commands = await decoder.DecodeCommands(Player);
+      _sendTask = Task.Run(() => SendLoopAsync(linkedToken), linkedToken);
+      _receiveTask = Task.Run(() => ReceiveLoopAsync(linkedToken), linkedToken);
 
-//                    foreach (ICommand command in commands)
-//                    {
-//                        await command.OnReceive(Player);
-//                    }
+      await Task.WhenAll(_sendTask, _receiveTask);
+    }
 
-//                    Logger.WithPlayer(Player).Verbose(
-//                      "Received commands: {{\n{Commands}\n}}",
-//                      string.Join(",\n", commands.Select((command) => $"    {command}"))
-//                    );
-//                }
-//                catch (InvalidPacketHeaderException exception)
-//                {
-//                    Logger.WithPlayer(Player).Warning(
-//                      "Invalid packet header. Expected data: {ExpectedData}. Actual data: {ActualData}. Is HTTP request: {IsHttp}",
-//                      InvalidPacketHeaderException.GetHex(exception.ExpectedData),
-//                      InvalidPacketHeaderException.GetHex(exception.ActualData),
-//                      exception.IsHttp
-//                    );
+    public bool QueueCommands(params ICommand[] commands) {
+      bool result = false;
+      foreach(ICommand command in commands) {
+        CommandSendOptions options = command.GetSendOptions();
+        options = options.WithEstimatedSize(Math.Max(options.EstimatedSize, 32));
+        try {
+          ICommandCodec codec = CommandCodecRegistry.GetByType(command.GetType());
+          int estimated = codec.EstimateSize(command);
+          if(estimated > 0) {
+            options = options.WithEstimatedSize(Math.Max(options.EstimatedSize, estimated));
+          }
+        } catch(KeyNotFoundException) {
+        }
+        if(TryEnqueue(command, options)) {
+          result = true;
+        }
+      }
 
-//                    if (exception.IsHttp)
-//                    {
-//                        // Send user-friendly error message
+      if(result) {
+        _sendSignal.Release();
+      }
 
-//                        string content = "<html>\n" +
-//                                         "<head>\n" +
-//                                         "  <meta charset=\"utf-8\">\n" +
-//                                         "  <title>Araumi</title>\n" +
-//                                         "</head>\n" +
-//                                         "<body>\n" +
-//                                         "  <h1>400 Bad Request</h1>\n" +
-//                                         "  <h2>" +
-//                                         "    You tried to access Araumi game server instead of the static server.<br />" +
-//                                         "    If you weren't expecting this error, contact project administration" +
-//                                         "  </h2>\n" +
-//                                         "  <hr />\n" +
-//                                         "  <h3>Araumi, <a href=\"https://github.com/Araumi-sh/Araumi\" target=\"_blank\" rel=\"noopener\">https://github.com/Araumi-sh/Araumi</a></h3>" +
-//                                         "</body>\n" +
-//                                         "</html>";
-//                        string response = $"HTTP/1.1 400 Bad Request\r\n" +
-//                                          $"Server: Araumi\r\n" +
-//                                          $"Connection: close\r\n" +
-//                                          $"Content-Length: {content.Length}\r\n" +
-//                                          $"\r\n" +
-//                                          $"{content}";
+      return result;
+    }
 
-//                        await Socket.SendAsync(Encoding.UTF8.GetBytes(response), SocketFlags.None);
-//                        Socket.Shutdown(SocketShutdown.Both);
-//                        Socket.Close();
+    public void Disconnect() {
+      if(_cts.IsCancellationRequested) {
+        return;
+      }
 
-//                        break;
-//                    }
-//                }
-//                catch (MissingTypeUidException exception)
-//                {
-//                    Logger.WithPlayer(Player).Warning(
-//                      "Missing TypeUid attribute for type {Type}",
-//                      exception.Type
-//                    );
-//                }
-//                catch (UnknownTypeUidException exception)
-//                {
-//                    Logger.WithPlayer(Player).Warning(
-//                      "Unknown TypeUid: {TypeUid}",
-//                      exception.TypeUid
-//                    );
-//                }
-//                catch (Exception exception)
-//                {
-//                    Logger.Error(
-//                      exception,
-//                      "Unexpected exception"
-//                    );
-//                    break;
-//                }
-//            }
-//        }
+      _cts.Cancel();
+      try {
+        _socket.Shutdown(SocketShutdown.Both);
+      } catch(SocketException) {
+      }
+      _socket.Close();
+    }
 
-//        public async Task SendPackets()
-//        {
-//            await foreach (ICommand command in CommandQueue)
-//            {
-//                await SendCommands(command);
-//            }
-//        }
+    public async ValueTask DisposeAsync() {
+      Disconnect();
+      if(_sendTask != null) await _sendTask.ConfigureAwait(false);
+      if(_receiveTask != null) await _receiveTask.ConfigureAwait(false);
+    }
 
-//        public void QueueCommands(params ICommand[] commands)
-//        {
-//            foreach (ICommand command in commands)
-//            {
-//                CommandQueue.Enqueue(command);
-//            }
-//        }
+    private bool TryEnqueue(ICommand command, CommandSendOptions options) {
+      if(!_quotaManager.TryReserve(options.Priority, options.EstimatedSize, out int ticket)) {
+        if(!EvictLowerPriority(options.EstimatedSize, options.Priority) ||
+           !_quotaManager.TryReserve(options.Priority, options.EstimatedSize, out ticket)) {
+          return false;
+        }
+      }
 
-//        public async Task SendCommands(params ICommand[] commands)
-//        {
-//            await using MemoryStream stream = new MemoryStream();
-//            await using BinaryWriter writer = new BigEndianBinaryWriter(stream);
-//            DataEncoder encoder = new DataEncoder(writer);
+      lock(_queueLock) {
+        if(!EnsureClientRoomLocked(options.EstimatedSize, options.Priority)) {
+          _quotaManager.Release(ticket);
+          return false;
+        }
 
-//            await encoder.EncodeCommands(commands);
+        _queues[(int) options.Priority].Enqueue(new QueuedCommand(command, options, ticket));
+        _queuedBytes += options.EstimatedSize;
+        return true;
+      }
+    }
 
-//            writer.Flush();
+    private bool EnsureClientRoom(int bytes, CommandPriority priority) {
+      lock(_queueLock) {
+        EvictLowerPriorityLocked(bytes, priority);
+        return _queuedBytes + bytes <= _config.PerClientSendQueueBytes;
+      }
+    }
 
-//            Logger.Verbose(
-//              "Sending commands: {{\n{Commands}\n}}",
-//              string.Join(",\n", commands.Select((command) => $"    {command}"))
-//            );
+    private bool EvictLowerPriority(int bytesNeeded, CommandPriority priority) {
+      lock(_queueLock) {
+        EvictLowerPriorityLocked(bytesNeeded, priority);
+        return _queuedBytes + bytesNeeded <= _config.PerClientSendQueueBytes;
+      }
+    }
 
-//            // Logger.Verbose("Sending {@Data}...", stream.ToArray());
+    private bool EnsureClientRoomLocked(int bytes, CommandPriority priority) {
+      if(_config.PerClientSendQueueBytes <= 0) {
+        return true;
+      }
 
-//            await Socket.SendAsync(stream.ToArray(), SocketFlags.None, _cancellationTokenSource.Token);
-//        }
-//    }
-//}
+      if(_queuedBytes + bytes <= _config.PerClientSendQueueBytes) {
+        return true;
+      }
+
+      EvictLowerPriorityLocked(bytes, priority);
+      return _queuedBytes + bytes <= _config.PerClientSendQueueBytes;
+    }
+
+    private void EvictLowerPriorityLocked(int bytesNeeded, CommandPriority priority) {
+      if(_queuedBytes + bytesNeeded <= _config.PerClientSendQueueBytes) {
+        return;
+      }
+
+      for(int p = _queues.Length - 1; p >= (int) priority; p--) {
+        Queue<QueuedCommand> queue = _queues[p];
+        while(queue.Count > 0 && _queuedBytes + bytesNeeded > _config.PerClientSendQueueBytes) {
+          QueuedCommand dropped = queue.Dequeue();
+          _quotaManager.Release(dropped.Ticket);
+          _queuedBytes -= dropped.Options.EstimatedSize;
+          PerfCounters.Increment("network.send.dropped", 1);
+        }
+
+        if(_queuedBytes + bytesNeeded <= _config.PerClientSendQueueBytes) {
+          return;
+        }
+      }
+    }
+
+    private async Task ReceiveLoopAsync(CancellationToken token) {
+      Task writingTask = Task.Run(() => FillPipeAsync(token), token);
+      Task readingTask = Task.Run(() => ReadPipeAsync(token), token);
+      await Task.WhenAll(writingTask, readingTask);
+    }
+
+    private async Task FillPipeAsync(CancellationToken token) {
+      try {
+        while(!token.IsCancellationRequested) {
+          Memory<byte> memory = _pipe.Writer.GetMemory(4096);
+          int bytesRead = await _socket.ReceiveAsync(memory, SocketFlags.None, token);
+          if(bytesRead == 0) {
+            Disconnect();
+            break;
+          }
+
+          _pipe.Writer.Advance(bytesRead);
+          FlushResult result = await _pipe.Writer.FlushAsync(token);
+          if(result.IsCompleted) {
+            break;
+          }
+        }
+      } catch(OperationCanceledException) {
+      } catch(Exception exception) {
+        Logger.Error(exception, "Receive loop failed");
+        Disconnect();
+      } finally {
+        await _pipe.Writer.CompleteAsync();
+      }
+    }
+
+    private async Task ReadPipeAsync(CancellationToken token) {
+      try {
+        while(true) {
+          ReadResult result = await _pipe.Reader.ReadAsync(token);
+          ReadOnlySequence<byte> buffer = result.Buffer;
+          SequencePosition consumed = buffer.Start;
+          SequencePosition examined = buffer.End;
+
+          while(TryReadFrame(ref buffer, out ReadOnlyMemory<byte> packet, out byte[]? rented)) {
+            consumed = buffer.Start;
+            examined = consumed;
+            try {
+              await HandlePacketAsync(packet, token);
+            } finally {
+              if(rented != null) {
+                _pool.Return(rented);
+              }
+            }
+          }
+
+          _pipe.Reader.AdvanceTo(consumed, examined);
+          if(result.IsCompleted) {
+            break;
+          }
+        }
+      } catch(OperationCanceledException) {
+      } catch(Exception exception) {
+        Logger.Error(exception, "Read loop failed");
+        Disconnect();
+      } finally {
+        await _pipe.Reader.CompleteAsync();
+      }
+    }
+
+    private bool TryReadFrame(ref ReadOnlySequence<byte> buffer, out ReadOnlyMemory<byte> packet, out byte[]? rented) {
+      packet = ReadOnlyMemory<byte>.Empty;
+      rented = null;
+      if(buffer.Length < sizeof(int)) {
+        return false;
+      }
+
+      SequenceReader<byte> reader = new SequenceReader<byte>(buffer);
+      if(!reader.TryReadBigEndian(out int length)) {
+        return false;
+      }
+
+      if(reader.Remaining < length) {
+        return false;
+      }
+
+      ReadOnlySequence<byte> payload = buffer.Slice(reader.Position, length);
+      if(payload.IsSingleSegment) {
+        packet = payload.First;
+      } else {
+        byte[] bufferArray = _pool.Rent(length);
+        payload.CopyTo(bufferArray);
+        packet = new ReadOnlyMemory<byte>(bufferArray, 0, length);
+        rented = bufferArray;
+      }
+
+      buffer = buffer.Slice(payload.End);
+      return true;
+    }
+
+    private async Task HandlePacketAsync(ReadOnlyMemory<byte> packet, CancellationToken token) {
+      DataDecoder decoder = new DataDecoder();
+      DecodedPacket decoded = decoder.Decode(packet, Player);
+      UpdateReceiveWindow(decoded.Sequence);
+      ProcessAck(decoded.Ack, decoded.AckMask);
+
+      foreach(ReceivedCommand received in decoded.Commands) {
+        if(!_antiFlood.TryConsume(Player, received.Command.GetType().Name, 1, DateTime.UtcNow)) {
+          Logger.Warning("Flood detected for player {Player}", Player.LogDisplay);
+          continue;
+        }
+
+        try {
+          await received.Command.OnReceive(Player);
+        } catch(Exception exception) {
+          Logger.Error(exception, "Error executing command");
+        }
+      }
+    }
+
+    private async Task SendLoopAsync(CancellationToken token) {
+      List<QueuedCommand> batch = new List<QueuedCommand>(_config.MaxCommandsPerBatch);
+      DataEncoder encoder = new DataEncoder(_pool);
+
+      try {
+        while(!token.IsCancellationRequested) {
+          await _sendSignal.WaitAsync(token);
+
+          if(!TryDequeueBatch(batch, out int _)) {
+            continue;
+          }
+
+          uint sequence = _nextOutboundSequence++;
+          uint ackSequence;
+          uint ackMask;
+          lock(_ackLock) {
+            ackSequence = _lastReceivedSequence;
+            ackMask = _receivedMask;
+          }
+          using IDisposable _ = PerfCounters.TrackDuration("network.send.encode");
+          using PooledPacket packet = encoder.Encode(batch, sequence, ackSequence, ackMask);
+          await _socket.SendAsync(new ReadOnlyMemory<byte>(packet.Buffer, 0, packet.Length), SocketFlags.None, token);
+
+          RegisterReliables(sequence, batch);
+          foreach(QueuedCommand command in batch) {
+            _quotaManager.Release(command.Ticket);
+          }
+
+          batch.Clear();
+          if(HasPendingCommands()) {
+            _sendSignal.Release();
+          }
+          CheckRetransmissions();
+        }
+      } catch(OperationCanceledException) {
+      } catch(Exception exception) {
+        Logger.Error(exception, "Send loop failed");
+        Disconnect();
+      }
+    }
+
+    private bool TryDequeueBatch(List<QueuedCommand> batch, out int bytes) {
+      batch.Clear();
+      bytes = 0;
+
+      lock(_queueLock) {
+        int maxBytes = _config.MaxBatchBytes;
+        int maxCommands = _config.MaxCommandsPerBatch;
+
+        for(int priority = 0; priority < _queues.Length; priority++) {
+          Queue<QueuedCommand> queue = _queues[priority];
+          while(queue.Count > 0) {
+            QueuedCommand command = queue.Peek();
+            if(batch.Count >= maxCommands) {
+              return batch.Count > 0;
+            }
+
+            if(bytes + command.Options.EstimatedSize > maxBytes && batch.Count > 0) {
+              break;
+            }
+
+            queue.Dequeue();
+            _queuedBytes -= command.Options.EstimatedSize;
+            batch.Add(command);
+            bytes += command.Options.EstimatedSize;
+          }
+        }
+      }
+
+      return batch.Count > 0;
+    }
+
+    private void RegisterReliables(uint sequence, List<QueuedCommand> batch) {
+      List<QueuedCommand> reliable = batch.Where(c => c.Options.Reliable).ToList();
+      if(reliable.Count == 0) {
+        return;
+      }
+
+      _pendingReliables[sequence] = new PendingReliable(sequence, reliable, DateTime.UtcNow, attempts: 1);
+    }
+
+    private void UpdateReceiveWindow(uint sequence) {
+      if(sequence == 0) {
+        return;
+      }
+
+      lock(_ackLock) {
+        if(sequence > _lastReceivedSequence) {
+          uint diff = sequence - _lastReceivedSequence;
+          if(diff >= 32) {
+            _receivedMask = 1;
+          } else {
+            _receivedMask = (_receivedMask << (int) diff) | 1;
+          }
+
+          _lastReceivedSequence = sequence;
+        } else {
+          uint offset = _lastReceivedSequence - sequence;
+          if(offset > 0 && offset <= 32) {
+            _receivedMask |= (uint) (1 << (int) (offset - 1));
+          }
+        }
+      }
+    }
+
+    private void ProcessAck(uint ack, uint ackMask) {
+      lock(_ackLock) {
+        _pendingReliables.Remove(ack);
+
+        for(int bit = 0; bit < 32; bit++) {
+          if(((ackMask >> bit) & 1) == 1) {
+            uint sequence = ack - (uint) (bit + 1);
+            _pendingReliables.Remove(sequence);
+          }
+        }
+      }
+    }
+
+    private void CheckRetransmissions() {
+      DateTime now = DateTime.UtcNow;
+      List<(uint Sequence, PendingReliable Pending)> toRetransmit = new List<(uint, PendingReliable)>();
+      lock(_ackLock) {
+        foreach(KeyValuePair<uint, PendingReliable> pair in _pendingReliables) {
+          if(now - pair.Value.LastSent >= TimeSpan.FromMilliseconds(200)) {
+            toRetransmit.Add((pair.Key, pair.Value));
+          }
+        }
+
+        foreach((uint Sequence, PendingReliable Pending) item in toRetransmit.ToArray()) {
+          if(item.Pending.Attempts >= 5) {
+            Logger.Warning("Dropping reliable packet {Sequence} for player {Player}", item.Sequence, Player.LogDisplay);
+            _pendingReliables.Remove(item.Sequence);
+            toRetransmit.Remove(item);
+          }
+        }
+
+        foreach((uint Sequence, PendingReliable Pending) item in toRetransmit) {
+          _pendingReliables[item.Sequence] = item.Pending with { LastSent = now, Attempts = item.Pending.Attempts + 1 };
+        }
+      }
+
+      foreach((uint Sequence, PendingReliable Pending) item in toRetransmit) {
+        foreach(QueuedCommand command in item.Pending.Commands) {
+          QueueCommands(command.Command);
+        }
+      }
+    }
+
+    private bool HasPendingCommands() {
+      lock(_queueLock) {
+        for(int i = 0; i < _queues.Length; i++) {
+          if(_queues[i].Count > 0) {
+            return true;
+          }
+        }
+      }
+
+      return false;
+    }
+
+    private readonly record struct PendingReliable(uint Sequence, IReadOnlyList<QueuedCommand> Commands, DateTime LastSent, int Attempts);
+  }
+}

--- a/UTanksServer/Services/Servers/Game/Connection/QueuedCommand.cs
+++ b/UTanksServer/Services/Servers/Game/Connection/QueuedCommand.cs
@@ -1,0 +1,17 @@
+using System;
+
+namespace UTanksServer.Services.Servers.Game.Connection {
+  public readonly struct QueuedCommand {
+    public QueuedCommand(ICommand command, CommandSendOptions options, int ticket) {
+      Command = command;
+      Options = options;
+      Ticket = ticket;
+      EnqueueTime = DateTime.UtcNow;
+    }
+
+    public ICommand Command { get; }
+    public CommandSendOptions Options { get; }
+    public int Ticket { get; }
+    public DateTime EnqueueTime { get; }
+  }
+}

--- a/UTanksServer/Services/Servers/Game/Connection/SendQuotaManager.cs
+++ b/UTanksServer/Services/Servers/Game/Connection/SendQuotaManager.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Threading;
+
+namespace UTanksServer.Services.Servers.Game.Connection {
+  public sealed class SendQuotaManager {
+    private readonly int _globalQueueLimitBytes;
+    private readonly int _criticalReserveBytes;
+    private int _globalInFlightBytes;
+
+    public SendQuotaManager(int globalQueueLimitBytes, double criticalReserveRatio = 0.1) {
+      _globalQueueLimitBytes = Math.Max(0, globalQueueLimitBytes);
+      _criticalReserveBytes = (int) Math.Max(0, globalQueueLimitBytes * criticalReserveRatio);
+    }
+
+    public bool TryReserve(CommandPriority priority, int bytes, out int ticket) {
+      ticket = 0;
+      if(bytes <= 0) {
+        return true;
+      }
+
+      while(true) {
+        int current = Volatile.Read(ref _globalInFlightBytes);
+        int limit = priority == CommandPriority.Critical ? _globalQueueLimitBytes : _globalQueueLimitBytes - _criticalReserveBytes;
+        if(limit <= 0 || current + bytes > limit) {
+          return false;
+        }
+
+        if(Interlocked.CompareExchange(ref _globalInFlightBytes, current + bytes, current) == current) {
+          ticket = bytes;
+          return true;
+        }
+      }
+    }
+
+    public void Release(int ticket) {
+      if(ticket <= 0) {
+        return;
+      }
+
+      Interlocked.Add(ref _globalInFlightBytes, -ticket);
+    }
+  }
+}

--- a/UTanksServer/Services/Servers/Game/GameServer.cs
+++ b/UTanksServer/Services/Servers/Game/GameServer.cs
@@ -1,86 +1,192 @@
-using System.Net;
-using System.Threading;
-using System.Net.Sockets;
-using System.Threading.Tasks;
+using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
 
 using Serilog;
 
-using UTanksServer.Extensions;
+using UTanksServer.Core.Logging;
+using UTanksServer.Core.Protocol;
+using UTanksServer.Diagnostics;
 using UTanksServer.Services.Servers.Game.Connection;
+using UTanksServer.Services.Servers.Game.Security;
+using UTanksServer.Services.Servers.Game.World;
 
 namespace UTanksServer.Services.Servers.Game {
   public interface IGameServer {
-    public Task Start();
+    Task StartAsync(CancellationToken cancellationToken);
   }
 
   public interface ICommand {
-    public Task OnReceive(Player player);
+    Task OnReceive(Player player);
   }
 
   [UTanksServer.ECS.ECSCore.Service]
-  public class GameServer : IGameServer {
-    private static readonly ILogger Logger = Log.Logger.ForType<GameServer>();
+  public sealed class GameServer : IGameServer, IAsyncDisposable {
+    private static readonly ILogger Logger = Log.Logger.ForContext<GameServer>();
 
     public IPEndPoint Endpoint { get; }
 
-    private readonly Socket _socket;
-    private readonly List<IPlayerConnection> _clients;
+    private readonly Socket _listener;
+    private readonly ConcurrentDictionary<Guid, PlayerSocketConnection> _connections = new ConcurrentDictionary<Guid, PlayerSocketConnection>();
+    private readonly GameServerConfig _config;
+    private readonly SendQuotaManager _quotaManager;
+    private readonly AntiFloodController _antiFlood = new AntiFloodController();
+    private readonly InterestManager _interestManager;
+    private readonly SnapshotCache _snapshotCache = new SnapshotCache();
 
-    private readonly IConfigService _configService;
+    private readonly CancellationTokenSource _cts = new CancellationTokenSource();
+
+    private Task? _acceptTask;
+    private Task? _tickTask;
 
     public GameServer(IConfigService configService) {
-      _configService = configService;
-
-      Endpoint = new IPEndPoint(_configService.GameServerConfig.Address, _configService.GameServerConfig.Port);
-
-      _socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
-      _clients = new List<IPlayerConnection>();
+      _config = configService.GameServerConfig;
+      Endpoint = new IPEndPoint(_config.Address, _config.Port);
+      _listener = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+      _quotaManager = new SendQuotaManager(_config.GlobalSendQueueBytes);
+      _interestManager = new InterestManager(_config.InterestCellSize, _config.InterestRadius);
+      CommandCodecBootstrapper.EnsureInitialized();
     }
 
-    public async Task Start() {
-      _socket.Bind(Endpoint);
-      _socket.Listen();
+    public async Task StartAsync(CancellationToken cancellationToken) {
+      _listener.Bind(Endpoint);
+      _listener.Listen(_config.Backlog);
 
       ThreadPool.SetMinThreads(50, 50);
 
-      _ = Task.Factory.StartNew(async () => {
-        while(true) {
-          IPlayerConnection connection = await AcceptClient();
+      using CancellationTokenSource linkedCts = CancellationTokenSource.CreateLinkedTokenSource(_cts.Token, cancellationToken);
+      CancellationToken token = linkedCts.Token;
 
-          _ = Task.Run(async () => await connection.ReceivePackets());
-          _ = Task.Run(async () => await connection.SendPackets());
-
-          _ = Task.Run(async () => {
-            await Task.Delay(1000); // TODO(Assasans): Find a better way to detect if it is HTTP request
-            await connection.Init();
-          });
-        }
-      }, TaskCreationOptions.LongRunning);
+      _acceptTask = Task.Run(() => AcceptLoopAsync(token), token);
+      _tickTask = Task.Run(() => TickLoopAsync(token), token);
 
       Logger.Information("Started game server: {Address}:{Port}", Endpoint.Address, Endpoint.Port);
-      Logger.Information("Initialized");
+      await Task.WhenAll(_acceptTask, _tickTask);
     }
 
-    private async Task<IPlayerConnection> AcceptClient() {
-      Logger.Verbose("Waiting for socket...");
+    public async ValueTask DisposeAsync() {
+      _cts.Cancel();
+      try {
+        _listener.Close();
+      } catch(SocketException) {
+      }
 
-      Socket clientSocket = await _socket.AcceptAsync();
+      if(_acceptTask != null) await _acceptTask.ConfigureAwait(false);
+      if(_tickTask != null) await _tickTask.ConfigureAwait(false);
 
+      foreach(PlayerSocketConnection connection in _connections.Values) {
+        await connection.DisposeAsync();
+      }
+    }
+
+    private async Task AcceptLoopAsync(CancellationToken token) {
+      Logger.Information("Accept loop started");
+      try {
+        while(!token.IsCancellationRequested) {
+          Socket clientSocket = await _listener.AcceptAsync();
+          token.ThrowIfCancellationRequested();
+          _ = Task.Run(() => HandleClientAsync(clientSocket, token), token);
+        }
+      } catch(OperationCanceledException) {
+      } catch(Exception exception) {
+        Logger.Error(exception, "Accept loop failed");
+      }
+    }
+
+    private async Task HandleClientAsync(Socket socket, CancellationToken token) {
       Player player = new Player();
-            //PlayerSocketConnection connection = new PlayerSocketConnection(clientSocket);
+      PlayerSocketConnection connection = new PlayerSocketConnection(socket, _config, _quotaManager, _antiFlood);
+      await connection.InitializeAsync(player, this, token);
+      player.Connection = connection;
 
-            //player.Connection = connection;
-            //connection.Player = player;
+      Guid id = Guid.NewGuid();
+      if(!_connections.TryAdd(id, connection)) {
+        Logger.Warning("Failed to track connection for player {Player}", player.LogDisplay);
+      }
 
-            //_clients.Add(connection);
+      Logger.Information("Accepted connection from {Endpoint}", socket.RemoteEndPoint);
 
-            //Logger.WithPlayer(connection.Player).Verbose(
-            //  "Accepted socket"
-            //);
+      try {
+        await connection.RunAsync(token);
+      } catch(Exception exception) {
+        Logger.Error(exception, "Connection loop failed");
+      } finally {
+        _connections.TryRemove(id, out _);
+        await connection.DisposeAsync();
+        Logger.Information("Connection closed: {Endpoint}", socket.RemoteEndPoint);
+      }
+    }
 
-            //return connection;
-            return null;
+    private async Task TickLoopAsync(CancellationToken token) {
+      TimeSpan tickInterval = TimeSpan.FromSeconds(1.0 / Math.Max(1, _config.TickRate));
+      Stopwatch stopwatch = Stopwatch.StartNew();
+
+      try {
+        while(!token.IsCancellationRequested) {
+          long startTicks = stopwatch.ElapsedTicks;
+
+          using IDisposable _ = PerfCounters.TrackDuration("tick.total");
+          RunTick();
+
+          long elapsedTicks = stopwatch.ElapsedTicks - startTicks;
+          double elapsedMilliseconds = elapsedTicks * 1000.0 / Stopwatch.Frequency;
+          PerfCounters.Increment("tick.duration", elapsedMilliseconds);
+
+          TimeSpan sleep = tickInterval - TimeSpan.FromMilliseconds(elapsedMilliseconds);
+          if(sleep > TimeSpan.Zero) {
+            try {
+              await Task.Delay(sleep, token);
+            } catch(TaskCanceledException) {
+              break;
+            }
+          }
+        }
+      } catch(OperationCanceledException) {
+      } catch(Exception exception) {
+        Logger.Error(exception, "Tick loop failed");
+      }
+    }
+
+    private void RunTick() {
+      ExecutePhase("tick.input", ProcessInputs);
+      ExecutePhase("tick.simulation", SimulateWorld);
+      ExecutePhase("tick.apply", ApplyResults);
+      ExecutePhase("tick.broadcast", BroadcastUpdates);
+    }
+
+    private void ExecutePhase(string name, Action action) {
+      using IDisposable _ = PerfCounters.TrackDuration(name);
+      action();
+    }
+
+    private void ProcessInputs() {
+      // Inputs are already processed in connection threads; gather metrics here if necessary.
+      PerfCounters.Increment("tick.inputs", _connections.Count);
+    }
+
+    private void SimulateWorld() {
+      // Placeholder for simulation logic. Parallelize heavy systems in the future.
+    }
+
+    private void ApplyResults() {
+      // Placeholder for applying simulation results to world state.
+    }
+
+    private void BroadcastUpdates() {
+      foreach(PlayerSocketConnection connection in _connections.Values) {
+        if(!connection.IsConnected) {
+          continue;
+        }
+
+        // For now we send heartbeat to keep the link alive and validate delta path.
+        connection.QueueCommands(new Core.Protocol.Commands.HeartbeatCommand { ClientTime = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() });
+      }
     }
   }
 }

--- a/UTanksServer/Services/Servers/Game/GameServerConfig.cs
+++ b/UTanksServer/Services/Servers/Game/GameServerConfig.cs
@@ -2,9 +2,21 @@ using System.Net;
 
 namespace UTanksServer.Services.Servers.Game {
   public class GameServerConfig {
-    public IPAddress Address { get; set; } = null!;
-    public IPAddress PublicAddress { get; set; } = null!;
+    public IPAddress Address { get; set; } = IPAddress.Any;
+    public IPAddress PublicAddress { get; set; } = IPAddress.Any;
+    public int Port { get; set; } = 5050;
+    public int Backlog { get; set; } = 128;
 
-    public int Port { get; set; }
+    public int TickRate { get; set; } = 60;
+    public int MaxPlayers { get; set; } = 1024;
+
+    public int PerClientSendQueueBytes { get; set; } = 64 * 1024;
+    public int GlobalSendQueueBytes { get; set; } = 8 * 1024 * 1024;
+
+    public int MaxBatchBytes { get; set; } = 1400;
+    public int MaxCommandsPerBatch { get; set; } = 64;
+
+    public float InterestCellSize { get; set; } = 20f;
+    public float InterestRadius { get; set; } = 60f;
   }
 }

--- a/UTanksServer/Services/Servers/Game/Security/AntiFloodController.cs
+++ b/UTanksServer/Services/Servers/Game/Security/AntiFloodController.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Collections.Concurrent;
+
+namespace UTanksServer.Services.Servers.Game.Security {
+  public sealed class AntiFloodController {
+    private readonly ConcurrentDictionary<string, TokenBucket> _buckets = new ConcurrentDictionary<string, TokenBucket>();
+
+    public bool TryConsume(Player player, string key, int cost, DateTime now) {
+      string bucketKey = $"{player.GetHashCode()}::{key}";
+      TokenBucket bucket = _buckets.GetOrAdd(bucketKey, _ => new TokenBucket(10, TimeSpan.FromSeconds(1)));
+      return bucket.TryConsume(cost, now);
+    }
+
+    private sealed class TokenBucket {
+      private readonly int _capacity;
+      private readonly TimeSpan _refillPeriod;
+      private double _tokens;
+      private DateTime _lastRefill;
+      private readonly object _sync = new object();
+
+      public TokenBucket(int capacity, TimeSpan refillPeriod) {
+        _capacity = capacity;
+        _refillPeriod = refillPeriod;
+        _tokens = capacity;
+        _lastRefill = DateTime.UtcNow;
+      }
+
+      public bool TryConsume(int cost, DateTime now) {
+        lock(_sync) {
+          Refill(now);
+          if(_tokens < cost) {
+            return false;
+          }
+
+          _tokens -= cost;
+          return true;
+        }
+      }
+
+      private void Refill(DateTime now) {
+        double periods = (now - _lastRefill).TotalMilliseconds / _refillPeriod.TotalMilliseconds;
+        if(periods <= 0) {
+          return;
+        }
+
+        _tokens = Math.Min(_capacity, _tokens + periods * _capacity);
+        _lastRefill = now;
+      }
+    }
+  }
+}

--- a/UTanksServer/Services/Servers/Game/World/InterestManager.cs
+++ b/UTanksServer/Services/Servers/Game/World/InterestManager.cs
@@ -1,0 +1,26 @@
+using System.Collections.Generic;
+using System.Numerics;
+
+namespace UTanksServer.Services.Servers.Game.World {
+  public sealed class InterestManager {
+    private readonly SpatialHashGrid<Player> _grid;
+    private readonly float _visibilityRadius;
+
+    public InterestManager(float cellSize, float visibilityRadius) {
+      _grid = new SpatialHashGrid<Player>(cellSize);
+      _visibilityRadius = visibilityRadius;
+    }
+
+    public void UpdatePlayer(Player player, long entityId, Vector3 position) {
+      _grid.Set(entityId, position, player);
+    }
+
+    public void RemovePlayer(long entityId, Vector3 position) {
+      _grid.Remove(entityId, position);
+    }
+
+    public IReadOnlyList<Player> Query(Vector3 position) {
+      return _grid.Query(position, _visibilityRadius);
+    }
+  }
+}

--- a/UTanksServer/Services/Servers/Game/World/SnapshotCache.cs
+++ b/UTanksServer/Services/Servers/Game/World/SnapshotCache.cs
@@ -1,0 +1,16 @@
+using System.Collections.Concurrent;
+
+namespace UTanksServer.Services.Servers.Game.World {
+  public sealed class SnapshotCache {
+    private readonly ConcurrentDictionary<Player, WorldSnapshot> _snapshots = new ConcurrentDictionary<Player, WorldSnapshot>();
+
+    public void Store(Player player, WorldSnapshot snapshot) {
+      _snapshots[player] = snapshot;
+    }
+
+    public WorldSnapshot Get(Player player) {
+      _snapshots.TryGetValue(player, out WorldSnapshot snapshot);
+      return snapshot;
+    }
+  }
+}

--- a/UTanksServer/Services/Servers/Game/World/SpatialHashGrid.cs
+++ b/UTanksServer/Services/Servers/Game/World/SpatialHashGrid.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Numerics;
+
+namespace UTanksServer.Services.Servers.Game.World {
+  public sealed class SpatialHashGrid<TValue> where TValue : class {
+    private readonly ConcurrentDictionary<(int, int), ConcurrentDictionary<long, (Vector3 Position, TValue Value)>> _cells = new ConcurrentDictionary<(int, int), ConcurrentDictionary<long, (Vector3, TValue)>>();
+    private readonly float _cellSize;
+
+    public SpatialHashGrid(float cellSize) {
+      _cellSize = Math.Max(1f, cellSize);
+    }
+
+    public void Set(long id, Vector3 position, TValue value) {
+      (int cellX, int cellY) = GetCell(position);
+      ConcurrentDictionary<long, (Vector3, TValue)> cell = _cells.GetOrAdd((cellX, cellY), _ => new ConcurrentDictionary<long, (Vector3, TValue)>());
+      cell[id] = (position, value);
+    }
+
+    public void Remove(long id, Vector3 position) {
+      (int cellX, int cellY) = GetCell(position);
+      if(_cells.TryGetValue((cellX, cellY), out ConcurrentDictionary<long, (Vector3, TValue)> cell)) {
+        cell.TryRemove(id, out _);
+      }
+    }
+
+    public List<TValue> Query(Vector3 position, float radius) {
+      List<TValue> results = new List<TValue>();
+      int minX = (int) Math.Floor((position.X - radius) / _cellSize);
+      int maxX = (int) Math.Floor((position.X + radius) / _cellSize);
+      int minY = (int) Math.Floor((position.Z - radius) / _cellSize);
+      int maxY = (int) Math.Floor((position.Z + radius) / _cellSize);
+
+      float radiusSquared = radius * radius;
+      for(int x = minX; x <= maxX; x++) {
+        for(int y = minY; y <= maxY; y++) {
+          if(!_cells.TryGetValue((x, y), out ConcurrentDictionary<long, (Vector3, TValue)> cell)) {
+            continue;
+          }
+
+          foreach((Vector3 candidatePosition, TValue value) in cell.Values) {
+            if(Vector3.DistanceSquared(candidatePosition, position) <= radiusSquared) {
+              results.Add(value);
+            }
+          }
+        }
+      }
+
+      return results;
+    }
+
+    private (int, int) GetCell(Vector3 position) {
+      int cellX = (int) Math.Floor(position.X / _cellSize);
+      int cellY = (int) Math.Floor(position.Z / _cellSize);
+      return (cellX, cellY);
+    }
+  }
+}

--- a/UTanksServer/Services/Servers/Game/World/WorldSnapshot.cs
+++ b/UTanksServer/Services/Servers/Game/World/WorldSnapshot.cs
@@ -1,0 +1,13 @@
+using System.Collections.Generic;
+
+namespace UTanksServer.Services.Servers.Game.World {
+  public sealed class WorldSnapshot {
+    public long Tick { get; init; }
+    public Dictionary<long, EntityState> Entities { get; } = new Dictionary<long, EntityState>();
+  }
+
+  public sealed class EntityState {
+    public long EntityId { get; init; }
+    public byte[] Payload { get; init; }
+  }
+}


### PR DESCRIPTION
## Summary
- implement a prioritized, quota-aware send queue with retransmission support in `PlayerSocketConnection`
- introduce pooled binary encoding/decoding infrastructure and register a heartbeat command codec
- refactor `GameServer` into a fixed-tick loop with observability hooks, anti-flood protection, and interest management scaffolding
- switch logging to an asynchronous channel-based writer and add diagnostics/perf counter utilities

## Testing
- not run (dotnet CLI unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e8027c43cc833191bc8126974c9c96